### PR TITLE
Adjust Daeyalt powermining behaviour

### DIFF
--- a/docs/src/content/docs/osb/Skills/mining.mdx
+++ b/docs/src/content/docs/osb/Skills/mining.mdx
@@ -209,7 +209,7 @@ The only other thing unidentified minerals can be used to purchase are:
 | Copper ore | 30 | 11,000 | Yes |  | No items |
 | Tin ore | 30 | 11,000 | Yes |  | No items |
 | Copper ore | 20 | 10,000 | Yes |  | No items |
-| Daeyalt essence rock | 70 | 10,000 | Yes |  | No items |
+| Daeyalt essence rock | 70 | 17,000 | Yes |  | No items |
 | Gold ore | 60 | 10,000 | Yes |  | No items |
 | Pure essence | 70 | 10,000 | Yes |  | No items |
 | Rune essence | 70 | 10,000 | Yes |  | No items |

--- a/src/lib/skilling/functions/determineMiningTime.ts
+++ b/src/lib/skilling/functions/determineMiningTime.ts
@@ -45,7 +45,14 @@ export function determineMiningTime({
 
 	const bankTime = goldSilverBoost ? ore.bankingTime / 3.3 : ore.bankingTime;
 	const chanceOfSuccess = ore.slope * miningLvl + intercept;
-	const respawnTimeOrPick = ticksBetweenRolls > ore.respawnTime ? ticksBetweenRolls : ore.respawnTime;
+
+	let effectiveTicksBetween = ticksBetweenRolls;
+	let respawnTimeOrPick = ticksBetweenRolls > ore.respawnTime ? ticksBetweenRolls : ore.respawnTime;
+	if (powermining && ore.name === 'Daeyalt essence rock') {
+		effectiveTicksBetween /= 1.7;
+		respawnTimeOrPick =
+			effectiveTicksBetween > ore.respawnTime / 1.7 ? effectiveTicksBetween : ore.respawnTime / 1.7;
+	}
 
 	let newQuantity = 0;
 
@@ -55,7 +62,11 @@ export function determineMiningTime({
 
 	let userMaxTripTicks = (maxTripLength - passedDuration) / (Time.Second * 0.6);
 
-	if (ore.name === 'Amethyst' || ore.name === 'Daeyalt essence rock') {
+	if (ore.name === 'Daeyalt essence rock') {
+		if (!powermining) {
+			userMaxTripTicks *= 1.5;
+		}
+	} else if (ore.name === 'Amethyst') {
 		userMaxTripTicks *= 1.5;
 	}
 
@@ -63,13 +74,13 @@ export function determineMiningTime({
 
 	while (timeElapsed < userMaxTripTicks) {
 		while (!percentChance(chanceOfSuccess)) {
-			timeElapsed += ticksBetweenRolls;
+			timeElapsed += effectiveTicksBetween;
 		}
 		if (remainingNoDeplete <= 0) {
 			timeElapsed += respawnTimeOrPick;
 			remainingNoDeplete = glovesEffect;
 		} else {
-			timeElapsed += ticksBetweenRolls;
+			timeElapsed += effectiveTicksBetween;
 			remainingNoDeplete--;
 		}
 		newQuantity++;


### PR DESCRIPTION
## Summary
- tweak Daeyalt powermining XP and trip length
- document new XP rate for Daeyalt

## Testing
- `pnpm lint` *(fails: unable to download prisma engine checksums)*
- `pnpm test` *(fails: multiple unit test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68433c1039448326a614a651853cd895