### PR TITLE
Fix mixology tests

### DIFF
--- a/src/mahoji/lib/abstracted_commands/masteringMixologyCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/masteringMixologyCommand.ts
@@ -1,6 +1,6 @@
 import { formatDuration, mentionCommand } from '@oldschoolgg/toolkit';
 import { Time } from 'e';
-import { Bank } from 'oldschooljs/dist/meta/types';
+import { Bank } from 'oldschooljs';
 import { QuestID } from '../../../lib/minions/data/quests';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type {

--- a/src/tasks/minions/minigames/masteringMixologyActivity.ts
+++ b/src/tasks/minions/minigames/masteringMixologyActivity.ts
@@ -6,6 +6,7 @@ import type {
 	MasteringMixologyContractActivityTaskOptions,
 	MasteringMixologyContractCreatingTaskOptions
 } from '../../../lib/types/minions';
+import { randFloat } from '../../../lib/util';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
 import {
@@ -13,21 +14,19 @@ import {
 	mixologyContracts,
 	mixologyHerbs
 } from '../../../mahoji/lib/abstracted_commands/masteringMixologyCommand';
-import { randFloat } from '../../../lib/util';
 
-interface WeightedItem {
-    weight: number;
-    [key: string]: any;
+export interface WeightedItem {
+	weight: number;
 }
 
-function masteringMixologyWeightedRandom<T extends WeightedItem>(items: readonly T[]): T {
-    const total = items.reduce((sum, item) => sum + item.weight, 0);
-    let roll = randFloat(0, total);
-    for (const item of items) {
-        roll -= item.weight;
-        if (roll <= 0) return item;
-    }
-    return items[items.length - 1];
+export function masteringMixologyWeightedRandom<T extends WeightedItem>(items: readonly T[]): T {
+	const total = items.reduce((sum, item) => sum + item.weight, 0);
+	let roll = randFloat(0, total);
+	for (const item of items) {
+		roll -= item.weight;
+		if (roll <= 0) return item;
+	}
+	return items[items.length - 1];
 }
 
 export const MixologyPasteCreationTask: MinionTask = {
@@ -83,11 +82,9 @@ export const MasteringMixologyContractTask: MinionTask = {
 
 		for (let i = 0; i < data.quantity; i++) {
 			const availableContracts = mixologyContracts.filter(contract => {
-					const counts: Record<'Mox' | 'Lye' | 'Aga', number> = { Mox: 0, Lye: 0, Aga: 0 };
-					for (const p of contract.pasteSequence) counts[p]++;
-					return Object.entries(counts).every(
-							([p, c]) => user.bank.amount(`${p} paste`) >= c
-					);
+				const counts: Record<'Mox' | 'Lye' | 'Aga', number> = { Mox: 0, Lye: 0, Aga: 0 };
+				for (const p of contract.pasteSequence) counts[p]++;
+				return Object.entries(counts).every(([p, c]) => user.bank.amount(`${p} paste`) >= c);
 			});
 			if (availableContracts.length === 0) break;
 

--- a/tests/integration/commands/masteringMixology.test.ts
+++ b/tests/integration/commands/masteringMixology.test.ts
@@ -1,85 +1,107 @@
 import { Bank } from 'oldschooljs';
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-
-import { MasteringMixologyContractStartCommand, MixologyPasteCreationCommand } from '../../../src/mahoji/lib/abstracted_commands/masteringMixologyCommand';
-import { MasteringMixologyContractTask, MixologyPasteCreationTask } from '../../../src/tasks/minions/minigames/masteringMixologyActivity';
+import {
+	MasteringMixologyContractStartCommand,
+	MixologyPasteCreationCommand
+} from '../../../src/mahoji/lib/abstracted_commands/masteringMixologyCommand';
+import {
+	MasteringMixologyContractTask,
+	MixologyPasteCreationTask,
+	masteringMixologyWeightedRandom
+} from '../../../src/tasks/minions/minigames/masteringMixologyActivity';
 import { createTestUser, mockUser } from '../util';
 
-const user = await createTestUser();
+describe('Mastering Mixology', async () => {
+	const user = await createTestUser();
 
-beforeEach(async () => {
-	await user.update({
-		bank: new Bank().add('Guam leaf', 5).add('Aga paste', 10).add('Mox paste', 10).add('Lye paste', 10),
-		skills_herblore: 5_000_000,
-		QP: 1,
-		finished_quest_ids: [3]
+	beforeEach(async () => {
+		await user.update({
+			bank: new Bank().add('Guam leaf', 5).add('Aga paste', 10).add('Mox paste', 10).add('Lye paste', 10),
+			skills_herblore: 5_000_000,
+			QP: 1,
+			finished_quest_ids: [3]
+		});
+	});
+
+	describe('MixologyPasteCreationCommand', () => {
+		test('invalid herb', async () => {
+			const res = await MixologyPasteCreationCommand(user, '1', 'invalid');
+			expect(res).toBe('That is not a valid herb for mixology paste.');
+		});
+
+		test('insufficient herb', async () => {
+			const u = await mockUser({ bank: new Bank() });
+			const res = await MixologyPasteCreationCommand(u, '1', 'Guam leaf');
+			expect(res).toBe("You don't have any Guam leaf to convert into Mox paste.");
+		});
+
+		test('quantity limit', async () => {
+			const res = await MixologyPasteCreationCommand(user, '1', 'Guam leaf', 99999);
+			expect(res).toContain("can't go on trips longer than");
+		});
+	});
+
+	describe('MasteringMixologyContractStartCommand', () => {
+		test('missing requirements', async () => {
+			const lowUser = await mockUser({ skills_herblore: 0 });
+			const res = await MasteringMixologyContractStartCommand(lowUser, '1');
+			expect(res).toBe('You need at least 60 Herblore to participate in the mixology.');
+		});
+
+		test('missing quest', async () => {
+			const noQuest = await mockUser({ skills_herblore: 6000000 });
+			const res = await MasteringMixologyContractStartCommand(noQuest, '1');
+			expect(res).toContain('You need to complete the "Children of the Sun" quest');
+		});
+
+		test('quantity bounds', async () => {
+			const res = await MasteringMixologyContractStartCommand(user, '1', 0);
+			expect(res).toContain('You can only complete between');
+		});
+	});
+
+	describe('Tasks', () => {
+		test('MixologyPasteCreationTask success', async () => {
+			await MixologyPasteCreationTask.run({
+				userID: user.id,
+				channelID: '1',
+				herbName: 'Guam leaf',
+				quantity: 1,
+				duration: 1,
+				type: 'MixologyPasteCreation',
+				minigameID: 'mastering_mixology'
+			});
+			expect(user.bank.amount('Mox paste')).toBeGreaterThan(10);
+		});
+
+		test('MasteringMixologyContractTask success', async () => {
+			vi.spyOn(Math, 'random').mockReturnValue(0);
+			await MasteringMixologyContractTask.run({
+				userID: user.id,
+				channelID: '1',
+				quantity: 1,
+				type: 'MasteringMixologyContract',
+				minigameID: 'mastering_mixology'
+			});
+			expect(user.bank.amount('Aga paste')).toBeLessThan(10);
+		});
+	});
+
+	describe('weightedRandom', () => {
+		test('follows weights', () => {
+			const items = [
+				{ weight: 1, id: 'a' },
+				{ weight: 2, id: 'b' },
+				{ weight: 3, id: 'c' }
+			];
+			const counts: Record<string, number> = { a: 0, b: 0, c: 0 };
+			for (let i = 0; i < 6000; i++) {
+				counts[masteringMixologyWeightedRandom(items).id]++;
+			}
+			const total = counts.a + counts.b + counts.c;
+			expect(counts.c / total).toBeGreaterThan(counts.b / total);
+			expect(counts.b / total).toBeGreaterThan(counts.a / total);
+		});
 	});
 });
-
-
-describe('MixologyPasteCreationCommand', () => {
-    test('invalid herb', async () => {
-        const res = await MixologyPasteCreationCommand(user, '1', 'invalid');
-        expect(res).toBe('That is not a valid herb for mixology paste.');
-    });
-
-    test('insufficient herb', async () => {
-        const u = mockUser({ bank: new Bank(), id: '2' });
-        const res = await MixologyPasteCreationCommand(u, '1', 'Guam leaf');
-        expect(res).toBe("You don't have any Guam leaf to convert into Mox paste.");
-    });
-
-    test('quantity limit', async () => {
-        const res = await MixologyPasteCreationCommand(user, '1', 'Guam leaf', 99999);
-        expect(res).toContain("can't go on trips longer than");
-    });
-});
-
-describe('MasteringMixologyContractStartCommand', () => {
-    test('missing requirements', async () => {
-        const lowUser = mockUser({ skills_herblore: 0, id: '3' });
-        const res = await MasteringMixologyContractStartCommand(lowUser as any, '1');
-        expect(res).toBe('You need at least 60 Herblore to participate in the mixology.');
-    });
-
-    test('missing quest', async () => {
-        const noQuest = mockUser({ skills_herblore: 6000000, id: '4' });
-        const res = await MasteringMixologyContractStartCommand(noQuest as any, '1');
-        expect(res).toContain('You need to complete the "Children of the Sun" quest');
-    });
-
-    test('quantity bounds', async () => {
-        const res = await MasteringMixologyContractStartCommand(user as any, '1', 0);
-        expect(res).toContain('You can only complete between');
-    });
-});
-
-describe('Tasks', () => {
-    test('MixologyPasteCreationTask success', async () => {
-        await MixologyPasteCreationTask.run({ userID: user.id, channelID: '1', herbName: 'Guam leaf', quantity: 1, duration: 1, type: 'MixologyPasteCreation', minigameID: 'mastering_mixology' });
-        expect(user.bank.amount('Mox paste')).toBeGreaterThan(10);
-    });
-
-    test('MasteringMixologyContractTask success', async () => {
-        vi.spyOn(Math, 'random').mockReturnValue(0);
-        await MasteringMixologyContractTask.run({ userID: user.id, channelID: '1', quantity: 1, type: 'MasteringMixologyContract', minigameID: 'mastering_mixology' });
-        expect(user.bank.amount('Aga paste')).toBeLessThan(10);
-    });
-});
-
-describe('weightedRandom', () => {
-    test('follows weights', () => {
-        const items = [
-            { weight: 1, id: 'a' },
-            { weight: 2, id: 'b' },
-            { weight: 3, id: 'c' }
-        ];
-        const counts: Record<string, number> = { a: 0, b: 0, c: 0 };
-        for (let i = 0; i < 6000; i++) {
-            counts[mastering(items).id]++;
-        }
-        const total = counts.a + counts.b + counts.c;
-        expect(counts.c / total).toBeGreaterThan(counts.b / total);
-        expect(counts.b / total).toBeGreaterThan(counts.a / total);
-    });


### PR DESCRIPTION
## Summary
- remove unneeded index signature for WeightedItem
- use async describe in mixology test and avoid `any` casts
- run linter to apply formatting

## Testing
- `pnpm test` *(fails: Command failed with exit code 1)*