### PR TITLE
Add perk-based return time display

### DIFF
--- a/packages/toolkit/src/util/datetime.ts
+++ b/packages/toolkit/src/util/datetime.ts
@@ -1,4 +1,6 @@
 import { Time } from 'e';
+import { time } from 'discord.js';
+import { dateFm, PerkTier } from './misc';
 
 export function isAtleastThisOld(date: Date | number, expectedAgeInMS: number) {
 	const difference = Date.now() - (typeof date === 'number' ? date : date.getTime());
@@ -32,7 +34,16 @@ export function formatDuration(ms: number, short = false, precise = false) {
 	if (nums.length === 0) {
 		return precise ? `${ms}ms` : 'less than 1 second';
 	}
-	return nums
-		.map(([key, val]) => `${val}${short ? '' : ' '}${key}${val === 1 || short ? '' : 's'}`)
-		.join(short ? '' : ', ');
+        return nums
+                .map(([key, val]) => `${val}${short ? '' : ' '}${key}${val === 1 || short ? '' : 's'}`)
+                .join(short ? '' : ', ');
+}
+
+export function formatDurationWithTimestamp(duration: number, perkTier: number) {
+       const base = formatDuration(duration);
+       if (perkTier >= PerkTier.Four) {
+               const finishDate = new Date(Date.now() + duration);
+               return `${base} (${dateFm(finishDate)})`;
+       }
+       return base;
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,10 +1,11 @@
 import {
 	type CommandResponse,
-	calcPerHour,
-	formatDuration,
-	isWeekend,
-	makeComponents,
-	stringMatches
+       calcPerHour,
+       formatDuration,
+       formatDurationWithTimestamp,
+       isWeekend,
+       makeComponents,
+       stringMatches
 } from '@oldschoolgg/toolkit/util';
 import {
 	type BaseMessageOptions,
@@ -40,7 +41,7 @@ import { sendToChannelID } from './util/webhook.js';
 
 export * from 'oldschooljs';
 
-export { stringMatches, calcPerHour, formatDuration, makeComponents, isWeekend };
+export { stringMatches, calcPerHour, formatDuration, formatDurationWithTimestamp, makeComponents, isWeekend };
 
 // @ts-ignore ignore
 BigInt.prototype.toJSON = function () {

--- a/src/mahoji/commands/build.ts
+++ b/src/mahoji/commands/build.ts
@@ -8,7 +8,7 @@ import { Bank } from 'oldschooljs';
 import Constructables from '../../lib/skilling/skills/construction/constructables';
 import type { Skills } from '../../lib/types';
 import type { ConstructionActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, hasSkillReqs } from '../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, hasSkillReqs } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
@@ -147,9 +147,10 @@ export const buildCommand: OSBMahojiCommand = {
 
 		const xpHr = `${(((object.xp * quantity) / (duration / Time.Minute)) * 60).toLocaleString()} XP/Hr`;
 
-		return `${user.minionName} is now constructing ${quantity}x ${object.name}, it'll take around ${formatDuration(
-			duration
-		)} to finish. Removed ${cost} from your bank. **${xpHr}**
+               return `${user.minionName} is now constructing ${quantity}x ${object.name}, it'll take around ${formatDurationWithTimestamp(
+                       duration,
+                       user.perkTier()
+               )} to finish. Removed ${cost} from your bank. **${xpHr}**
 
 You paid ${gpNeeded.toLocaleString()} GP, because you used ${invsPerTrip} inventories of planks.
 `;

--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -8,7 +8,7 @@ import { TWITCHERS_GLOVES } from '../../lib/constants';
 import { determineWoodcuttingTime } from '../../lib/skilling/functions/determineWoodcuttingTime';
 import Woodcutting from '../../lib/skilling/skills/woodcutting/woodcutting';
 import type { WoodcuttingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, itemNameFromID, randomVariation, stringMatches } from '../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, itemNameFromID, randomVariation, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import itemID from '../../lib/util/itemID';
 import { minionName } from '../../lib/util/minionUtils';
@@ -247,11 +247,11 @@ export const chopCommand: OSBMahojiCommand = {
 
 		let response = `${minionName(user)} is now chopping ${log.name} until your minion ${
 			quantity ? `chopped ${newQuantity}x or gets tired` : 'is satisfied'
-		}, it'll take ${
-			quantity
-				? `between ${formatDuration(fakeDurationMin)} **and** ${formatDuration(fakeDurationMax)}`
-				: formatDuration(duration)
-		} to finish.`;
+               }, it'll take ${
+                       quantity
+                               ? `between ${formatDurationWithTimestamp(fakeDurationMin, user.perkTier())} **and** ${formatDurationWithTimestamp(fakeDurationMax, user.perkTier())}`
+                               : formatDurationWithTimestamp(duration, user.perkTier())
+               } to finish.`;
 
 		if (boosts.length > 0) {
 			response += `\n\n**Boosts:** ${boosts.join(', ')}.`;

--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -11,7 +11,7 @@ import { allOpenables, getOpenableLoot } from '../../lib/openables';
 import { getPOHObject } from '../../lib/poh';
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { ClueActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, isWeekend, stringMatches } from '../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, isWeekend, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { getItem } from '../../lib/util/getOSItem';
@@ -452,7 +452,7 @@ export const clueCommand: OSBMahojiCommand = {
 
 		response.content = `${user.minionName} is now completing ${cluesDone}x ${
 			clueTier.name
-		} clues, it'll take around ${formatDuration(duration)} to finish (${((cluesDone / duration) * 3600000).toFixed(1)}/hr).${
+               } clues, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish (${((cluesDone / duration) * 3600000).toFixed(1)}/hr).${
 			boosts.length > 0 ? `\n\n**Boosts:** ${boosts.join(', ')}.` : ''
 		}${implingLootString}`;
 		return response;

--- a/src/mahoji/commands/cook.ts
+++ b/src/mahoji/commands/cook.ts
@@ -8,7 +8,7 @@ import Cooking, { Cookables } from '../../lib/skilling/skills/cooking/cooking';
 import ForestryRations from '../../lib/skilling/skills/cooking/forestersRations';
 import LeapingFish from '../../lib/skilling/skills/cooking/leapingFish';
 import type { CookingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, itemID, stringMatches } from '../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, itemID, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { cutLeapingFishCommand } from '../lib/abstracted_commands/cutLeapingFishCommand';
@@ -150,8 +150,9 @@ export const cookCommand: OSBMahojiCommand = {
 			type: 'Cooking'
 		});
 
-		return `${user.minionName} is now cooking ${quantity}x ${cookable.name}, it'll take around ${formatDuration(
-			duration
-		)} to finish.${boosts.length > 0 ? `\n\nBoosts: ${boosts.join(', ')}` : ''}`;
+               return `${user.minionName} is now cooking ${quantity}x ${cookable.name}, it'll take around ${formatDurationWithTimestamp(
+                       duration,
+                       user.perkTier()
+               )} to finish.${boosts.length > 0 ? `\n\nBoosts: ${boosts.join(', ')}` : ''}`;
 	}
 };

--- a/src/mahoji/commands/craft.ts
+++ b/src/mahoji/commands/craft.ts
@@ -3,7 +3,7 @@ import type { CommandRunOptions } from '@oldschoolgg/toolkit/util';
 import { ApplicationCommandOptionType } from 'discord.js';
 import { Time } from 'e';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import { FaladorDiary, userhasDiaryTier } from '../../lib/diaries';
 import { Craftables } from '../../lib/skilling/skills/crafting/craftables';
 import { SkillsEnum } from '../../lib/skilling/types';
@@ -124,8 +124,8 @@ export const craftCommand: OSBMahojiCommand = {
 			type: 'Crafting'
 		});
 
-		return `${user.minionName} is now crafting ${quantity}${sets} ${
-			craftable.name
-		}, it'll take around ${formatDuration(duration)} to finish. Removed ${itemsNeeded} from your bank.`;
+               return `${user.minionName} is now crafting ${quantity}${sets} ${
+                       craftable.name
+               }, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish. Removed ${itemsNeeded} from your bank.`;
 	}
 };

--- a/src/mahoji/commands/fish.ts
+++ b/src/mahoji/commands/fish.ts
@@ -7,7 +7,7 @@ import { Bank, Monsters } from 'oldschooljs';
 import Fishing from '../../lib/skilling/skills/fishing';
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { FishingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, itemID, itemNameFromID } from '../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, itemID, itemNameFromID } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import type { OSBMahojiCommand } from '../lib/util';
@@ -201,9 +201,10 @@ export const fishCommand: OSBMahojiCommand = {
 			flakesQuantity
 		});
 
-		let response = `${user.minionName} is now fishing ${quantity}x ${fish.name}, it'll take around ${formatDuration(
-			duration
-		)} to finish.`;
+               let response = `${user.minionName} is now fishing ${quantity}x ${fish.name}, it'll take around ${formatDurationWithTimestamp(
+                       duration,
+                       user.perkTier()
+               )} to finish.`;
 
 		if (boosts.length > 0) {
 			response += `\n\n**Boosts:** ${boosts.join(', ')}.`;

--- a/src/mahoji/commands/fletch.ts
+++ b/src/mahoji/commands/fletch.ts
@@ -3,7 +3,7 @@ import type { CommandRunOptions } from '@oldschoolgg/toolkit/util';
 import { ApplicationCommandOptionType } from 'discord.js';
 import { Time } from 'e';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import Fletching from '../../lib/skilling/skills/fletching';
 import { Fletchables } from '../../lib/skilling/skills/fletching/fletchables';
 import type { SlayerTaskUnlocksEnum } from '../../lib/slayer/slayerUnlocks';
@@ -114,8 +114,8 @@ export const fletchCommand: OSBMahojiCommand = {
 			type: 'Fletching'
 		});
 
-		return `${user.minionName} is now Fletching ${quantity}${sets} ${
-			fletchable.name
-		}, it'll take around ${formatDuration(duration)} to finish. Removed ${itemsNeeded} from your bank.`;
+               return `${user.minionName} is now Fletching ${quantity}${sets} ${
+                       fletchable.name
+               }, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish. Removed ${itemsNeeded} from your bank.`;
 	}
 };

--- a/src/mahoji/commands/hunt.ts
+++ b/src/mahoji/commands/hunt.ts
@@ -13,7 +13,7 @@ import Hunter from '../../lib/skilling/skills/hunter/hunter';
 import { HunterTechniqueEnum, SkillsEnum } from '../../lib/skilling/types';
 import type { Peak } from '../../lib/tickers';
 import type { HunterActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, hasSkillReqs, itemID } from '../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, hasSkillReqs, itemID } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
@@ -280,9 +280,9 @@ export const huntCommand: OSBMahojiCommand = {
 			type: 'Hunter'
 		});
 
-		let response = `${user.minionName} is now ${crystalImpling ? 'hunting' : `${creature.huntTechnique}`}${
-			crystalImpling ? ' ' : ` ${quantity}x `
-		}${creature.name}, it'll take around ${formatDuration(duration)} to finish.`;
+               let response = `${user.minionName} is now ${crystalImpling ? 'hunting' : `${creature.huntTechnique}`}${
+                       crystalImpling ? ' ' : ` ${quantity}x `
+               }${creature.name}, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.`;
 
 		if (boosts.length > 0) {
 			response += `\n\n**Boosts:** ${boosts.join(', ')}.`;

--- a/src/mahoji/commands/laps.ts
+++ b/src/mahoji/commands/laps.ts
@@ -7,7 +7,7 @@ import { quests } from '../../lib/minions/data/quests';
 import { courses } from '../../lib/skilling/skills/agility';
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { AgilityActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, stringMatches } from '../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
@@ -160,9 +160,9 @@ export const lapsCommand: OSBMahojiCommand = {
 			)}.`;
 		}
 
-		let response = `${user.minionName} is now doing ${quantity}x ${
-			course.name
-		} laps, it'll take around ${formatDuration(duration)} to finish.`;
+               let response = `${user.minionName} is now doing ${quantity}x ${
+                       course.name
+               } laps, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.`;
 
 		const alchResult = course.name === 'Ape Atoll Agility Course' || !options.alch ? null : alching(user, duration);
 		if (alchResult !== null) {

--- a/src/mahoji/commands/light.ts
+++ b/src/mahoji/commands/light.ts
@@ -4,7 +4,7 @@ import { ApplicationCommandOptionType } from 'discord.js';
 import { Time } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import Firemaking from '../../lib/skilling/skills/firemaking';
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { FiremakingActivityTaskOptions } from '../../lib/types/minions';
@@ -92,8 +92,9 @@ export const lightCommand: OSBMahojiCommand = {
 			type: 'Firemaking'
 		});
 
-		return `${user.minionName} is now lighting ${quantity}x ${log.name}, it'll take around ${formatDuration(
-			duration
-		)} to finish.`;
+               return `${user.minionName} is now lighting ${quantity}x ${log.name}, it'll take around ${formatDurationWithTimestamp(
+                       duration,
+                       user.perkTier()
+               )} to finish.`;
 	}
 };

--- a/src/mahoji/commands/mine.ts
+++ b/src/mahoji/commands/mine.ts
@@ -13,7 +13,7 @@ import Mining from '../../lib/skilling/skills/mining';
 import type { Ore } from '../../lib/skilling/types';
 import type { GearBank } from '../../lib/structures/GearBank';
 import type { MiningActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatSkillRequirements, itemNameFromID, randomVariation } from '../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, formatSkillRequirements, itemNameFromID, randomVariation } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import itemID from '../../lib/util/itemID';
@@ -262,11 +262,11 @@ export const mineCommand: OSBMahojiCommand = {
 
 		let response = `${minionName(user)} is now mining ${ore.name} until your minion ${
 			quantity ? `mined ${quantity}x or gets tired` : 'is satisfied'
-		}, it'll take ${
-			quantity
-				? `between ${formatDuration(res.fakeDurationMin)} **and** ${formatDuration(res.fakeDurationMax)}`
-				: formatDuration(res.duration)
-		} to finish.`;
+               }, it'll take ${
+                       quantity
+                               ? `between ${formatDurationWithTimestamp(res.fakeDurationMin, user.perkTier())} **and** ${formatDurationWithTimestamp(res.fakeDurationMax, user.perkTier())}`
+                               : formatDurationWithTimestamp(res.duration, user.perkTier())
+               } to finish.`;
 
 		if (res.boosts.length > 0) {
 			response += `\n\n**Boosts:** ${res.boosts.join(', ')}.`;

--- a/src/mahoji/commands/mix.ts
+++ b/src/mahoji/commands/mix.ts
@@ -4,7 +4,7 @@ import { ApplicationCommandOptionType } from 'discord.js';
 import { Time } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import Herblore from '../../lib/skilling/skills/herblore/herblore';
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { HerbloreActivityTaskOptions } from '../../lib/types/minions';
@@ -141,8 +141,8 @@ export const mixCommand: OSBMahojiCommand = {
 			type: 'Herblore'
 		});
 
-		return `${user.minionName} ${cost} making ${quantity}x ${
-			mixableItem.outputMultiple ? 'batches of' : ''
-		}${itemName}, it'll take around ${formatDuration(quantity * timeToMixSingleItem)} to finish.`;
+               return `${user.minionName} ${cost} making ${quantity}x ${
+                       mixableItem.outputMultiple ? 'batches of' : ''
+               }${itemName}, it'll take around ${formatDurationWithTimestamp(quantity * timeToMixSingleItem, user.perkTier())} to finish.`;
 	}
 };

--- a/src/mahoji/commands/offer.ts
+++ b/src/mahoji/commands/offer.ts
@@ -5,7 +5,7 @@ import { ApplicationCommandOptionType } from 'discord.js';
 import { Time, randArrItem, randInt, roll } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import { resolveItems } from 'oldschooljs/dist/util/util';
 import { Events } from '../../lib/constants';
 import { evilChickenOutfit } from '../../lib/data/CollectionsExport';
@@ -282,8 +282,8 @@ export const offerCommand: OSBMahojiCommand = {
 			duration,
 			type: 'Offering'
 		});
-		return `${user.minionName} is now offering ${quantity}x ${
-			bone.name
-		} at the Chaos altar, it'll take around ${formatDuration(duration)} to finish.`;
+               return `${user.minionName} is now offering ${quantity}x ${
+                       bone.name
+               } at the Chaos altar, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.`;
 	}
 };

--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -9,7 +9,7 @@ import { darkAltarCommand } from '../../lib/minions/functions/darkAltarCommand';
 import { sinsOfTheFatherSkillRequirements } from '../../lib/skilling/functions/questRequirements';
 import Runecraft from '../../lib/skilling/skills/runecraft';
 import type { RunecraftActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatSkillRequirements, itemID, stringMatches } from '../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, formatSkillRequirements, itemID, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { determineRunes } from '../../lib/util/determineRunes';
@@ -359,9 +359,10 @@ export const runecraftCommand: OSBMahojiCommand = {
 			response += ' Pure ';
 		}
 
-		response += `Essence into ${runeObj.name}, it'll take around ${formatDuration(
-			duration
-		)} to finish, this will take ${numberOfInventories}x trips to the altar. You'll get ${
+               response += `Essence into ${runeObj.name}, it'll take around ${formatDurationWithTimestamp(
+                       duration,
+                       user.perkTier()
+               )} to finish, this will take ${numberOfInventories}x trips to the altar. You'll get ${
 			quantityPerEssence * quantity
 		}x runes due to the multiplier.\n\n**Boosts:** ${boosts.join(', ')}`;
 

--- a/src/mahoji/commands/smelt.ts
+++ b/src/mahoji/commands/smelt.ts
@@ -7,7 +7,7 @@ import { resolveItems } from 'oldschooljs/dist/util/util';
 import Smithing from '../../lib/skilling/skills/smithing';
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { SmeltingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatSkillRequirements, itemID, stringMatches } from '../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, formatSkillRequirements, itemID, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
@@ -168,9 +168,9 @@ export const smeltingCommand: OSBMahojiCommand = {
 			boosts.push('56.2 xp per gold bar for Goldsmith gauntlets');
 		}
 
-		const response = `${user.minionName} is now smelting ${quantity}x ${
-			bar.name
-		}, it'll take around ${formatDuration(duration)} to finish. ${
+               const response = `${user.minionName} is now smelting ${quantity}x ${
+                       bar.name
+               }, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish. ${
 			blast_furnace ? `You paid ${coinsToRemove} GP to use the Blast Furnace.` : ''
 		} ${boosts.length > 0 ? `\n\n**Boosts: ** ${boosts.join(', ')}` : ''}`;
 

--- a/src/mahoji/commands/smith.ts
+++ b/src/mahoji/commands/smith.ts
@@ -8,7 +8,7 @@ import Smithing from '../../lib/skilling/skills/smithing';
 import smithables from '../../lib/skilling/skills/smithing/smithables';
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { SmithingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, stringMatches } from '../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { pluraliseItemName } from '../../lib/util/smallUtils';
@@ -148,7 +148,7 @@ export const smithCommand: OSBMahojiCommand = {
 
 		return `${user.minionName} is now smithing ${quantity * smithedItem.outputMultiple}x ${
 			smithedItem.name
-		}, removed ${cost} from your bank, it'll take around ${formatDuration(duration)} to finish. ${
+               }, removed ${cost} from your bank, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish. ${
 			setBonus > 0
 				? `${setBonus}% chance to save 1 tick while smithing each item for using Smiths' Uniform item/items.`
 				: ''

--- a/src/mahoji/commands/steal.ts
+++ b/src/mahoji/commands/steal.ts
@@ -4,7 +4,7 @@ import type { User } from 'discord.js';
 import { ApplicationCommandOptionType, bold } from 'discord.js';
 import { randInt } from 'e';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import { ArdougneDiary, userhasDiaryTier } from '../../lib/diaries';
 import { quests } from '../../lib/minions/data/quests';
 import removeFoodFromUser from '../../lib/minions/functions/removeFoodFromUser';
@@ -132,9 +132,9 @@ export const stealCommand: OSBMahojiCommand = {
 		let xpReceived = 0;
 		let damageTaken = 0;
 
-		let str = `${user.minionName} is now going to ${
-			stealable.type === 'pickpockable' ? 'pickpocket' : 'steal from'
-		} a ${stealable.name} ${quantity}x times, it'll take around ${formatDuration(duration)} to finish.`;
+               let str = `${user.minionName} is now going to ${
+                       stealable.type === 'pickpockable' ? 'pickpocket' : 'steal from'
+               } a ${stealable.name} ${quantity}x times, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.`;
 
 		if (stealable.type === 'pickpockable') {
 			const [hasArdyHard] = await userhasDiaryTier(user, ArdougneDiary.hard);

--- a/src/mahoji/lib/abstracted_commands/aerialFishingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/aerialFishingCommand.ts
@@ -2,7 +2,7 @@ import { Time } from 'e';
 
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { ActivityTaskOptionsWithQuantity } from '../../../lib/types/minions';
-import { formatDuration, randomVariation } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 
@@ -23,5 +23,5 @@ export async function aerialFishingCommand(user: MUser, channelID: string) {
 		type: 'AerialFishing'
 	});
 
-	return `${user.minionName} is now doing Aerial fishing, it will take around ${formatDuration(duration)} to finish.`;
+       return `${user.minionName} is now doing Aerial fishing, it will take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.`;
 }

--- a/src/mahoji/lib/abstracted_commands/alchCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/alchCommand.ts
@@ -5,7 +5,7 @@ import { SkillsEnum } from 'oldschooljs/dist/constants';
 
 import { resolveItems } from 'oldschooljs/dist/util/util';
 import type { AlchingActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, toKMB } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, toKMB } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { getItem } from '../../../lib/util/getOSItem';
@@ -106,9 +106,10 @@ export async function alchCommand(
 		type: 'Alching'
 	});
 
-	const response = `${user.minionName} is now alching ${quantity}x ${osItem.name}, it'll take around ${formatDuration(
-		duration
-	)} to finish.`;
+       const response = `${user.minionName} is now alching ${quantity}x ${osItem.name}, it'll take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )} to finish.`;
 
 	return response;
 }

--- a/src/mahoji/lib/abstracted_commands/buryCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/buryCommand.ts
@@ -4,7 +4,7 @@ import { Bank } from 'oldschooljs';
 import Prayer from '../../../lib/skilling/skills/prayer';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { BuryingActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, stringMatches } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 
@@ -60,5 +60,5 @@ export async function buryCommand(user: MUser, channelID: string, boneName: stri
 		type: 'Burying'
 	});
 
-	return `${user.minionName} is now burying ${cost}, it'll take around ${formatDuration(duration)} to finish.`;
+       return `${user.minionName} is now burying ${cost}, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.`;
 }

--- a/src/mahoji/lib/abstracted_commands/camdozaalCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/camdozaalCommand.ts
@@ -7,7 +7,7 @@ import { pickaxes } from '../../../lib/skilling/functions/miningBoosts';
 import Fishing from '../../../lib/skilling/skills/fishing';
 import Mining from '../../../lib/skilling/skills/mining';
 import type { ActivityTaskOptionsWithQuantity } from '../../../lib/types/minions';
-import { formatDuration, itemNameFromID, randomVariation } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, itemNameFromID, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { minionName } from '../../../lib/util/minionUtils';
@@ -72,13 +72,13 @@ async function miningCommand(user: MUser, channelID: string, quantity: number | 
 		type: 'CamdozaalMining'
 	});
 
-	let response = `${minionName(user)} is now mining inside the Ruins of Camdozaal until your minion ${
-		quantity ? `mined ${quantity}x barronite rocks or gets tired` : 'is satisfied'
-	}, it'll take ${
-		quantity
-			? `between ${formatDuration(fakeDurationMin)} **and** ${formatDuration(fakeDurationMax)}`
-			: formatDuration(duration)
-	} to finish.`;
+       let response = `${minionName(user)} is now mining inside the Ruins of Camdozaal until your minion ${
+               quantity ? `mined ${quantity}x barronite rocks or gets tired` : 'is satisfied'
+       }, it'll take ${
+               quantity
+                       ? `between ${formatDurationWithTimestamp(fakeDurationMin, user.perkTier())} **and** ${formatDurationWithTimestamp(fakeDurationMax, user.perkTier())}`
+                       : formatDurationWithTimestamp(duration, user.perkTier())
+       } to finish.`;
 
 	if (boosts.length > 0) {
 		response += `\n\n**Boosts:** ${boosts.join(', ')}.`;
@@ -126,9 +126,10 @@ async function smithingCommand(user: MUser, channelID: string, quantity: number 
 		type: 'CamdozaalSmithing'
 	});
 
-	return `${user.minionName} is now smithing in the Ruins of Camdozaal, it will take around ${formatDuration(
-		duration
-	)} to finish.`;
+       return `${user.minionName} is now smithing in the Ruins of Camdozaal, it will take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )} to finish.`;
 }
 
 async function fishingCommand(user: MUser, channelID: string, quantity: number | undefined) {
@@ -163,9 +164,10 @@ async function fishingCommand(user: MUser, channelID: string, quantity: number |
 		type: 'CamdozaalFishing'
 	});
 
-	return `${user.minionName} is now fishing in the Ruins of Camdozaal, it will take around ${formatDuration(
-		duration
-	)} to finish.`;
+       return `${user.minionName} is now fishing in the Ruins of Camdozaal, it will take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )} to finish.`;
 }
 export async function camdozaalCommand(user: MUser, channelID: string, choice: string, quantity: number | undefined) {
 	const qp = user.QP;

--- a/src/mahoji/lib/abstracted_commands/castCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/castCommand.ts
@@ -3,7 +3,7 @@ import { SkillsEnum } from 'oldschooljs/dist/constants';
 
 import { Castables } from '../../../lib/skilling/skills/magic/castables';
 import type { CastingActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, stringMatches } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { determineRunes } from '../../../lib/util/determineRunes';
@@ -123,9 +123,10 @@ export async function castCommand(channelID: string, user: MUser, name: string, 
 		((spell.xp * quantity) / (duration / Time.Minute)) * 60
 	).toLocaleString()} Magic XP/Hr`;
 
-	let response = `${user.minionName} is now casting ${quantity}x ${spell.name}, it'll take around ${formatDuration(
-		duration
-	)} to finish. Removed ${cost}${spell.gpCost ? ` and ${gpCost} Coins` : ''} from your bank. **${magicXpHr}**`;
+       let response = `${user.minionName} is now casting ${quantity}x ${spell.name}, it'll take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )} to finish. Removed ${cost}${spell.gpCost ? ` and ${gpCost} Coins` : ''} from your bank. **${magicXpHr}**`;
 
 	if (spell.craftXp) {
 		response += ` and** ${Math.round(

--- a/src/mahoji/lib/abstracted_commands/castleWarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/castleWarsCommand.ts
@@ -1,6 +1,6 @@
 import { Time } from 'e';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import { getMinigameEntity } from '../../../lib/settings/settings';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
@@ -21,9 +21,9 @@ export async function castleWarsStartCommand(user: MUser, channelID: string) {
 		minigameID: 'castle_wars'
 	});
 
-	return `${
-		user.minionName
-	} is now doing ${quantity} games of Castle Wars. The trip will take around ${formatDuration(duration)}.`;
+       return `${
+               user.minionName
+       } is now doing ${quantity} games of Castle Wars. The trip will take around ${formatDurationWithTimestamp(duration, user.perkTier())}.`;
 }
 export async function castleWarsStatsCommand(user: MUser) {
 	const { bank } = user;

--- a/src/mahoji/lib/abstracted_commands/chargeGloriesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/chargeGloriesCommand.ts
@@ -1,7 +1,7 @@
 import { Time } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import { WildernessDiary, userhasDiaryTier } from '../../../lib/diaries';
 import type { ActivityTaskOptionsWithQuantity } from '../../../lib/types/minions';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
@@ -59,9 +59,10 @@ export async function chargeGloriesCommand(user: MUser, channelID: string, quant
 
 	return `${
 		user.minionName
-	} is now charging ${quantityGlories} Amulets of glory, doing ${gloriesInventorySize} glories in ${quantity} trips, it'll take around ${formatDuration(
-		duration
-	)} to finish. Removed ${quantityGlories}x Amulet of glory from your bank.${
+       } is now charging ${quantityGlories} Amulets of glory, doing ${gloriesInventorySize} glories in ${quantity} trips, it'll take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )} to finish. Removed ${quantityGlories}x Amulet of glory from your bank.${
 		hasDiary ? ' 3x Boost for Wilderness Elite diary.' : ''
 	}`;
 }

--- a/src/mahoji/lib/abstracted_commands/chargeWealthCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/chargeWealthCommand.ts
@@ -1,7 +1,7 @@
 import { Time } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import { WildernessDiary, userhasDiaryTier } from '../../../lib/diaries';
 import type { ActivityTaskOptionsWithQuantity } from '../../../lib/types/minions';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
@@ -59,9 +59,10 @@ export async function chargeWealthCommand(user: MUser, channelID: string, quanti
 
 	return `${
 		user.minionName
-	} is now charging ${quantityWealths} Rings of wealth, doing ${wealthInventorySize} Rings of wealth in ${quantity} trips, it'll take around ${formatDuration(
-		duration
-	)} to finish. Removed ${quantityWealths}x Ring of wealth from your bank.${
+       } is now charging ${quantityWealths} Rings of wealth, doing ${wealthInventorySize} Rings of wealth in ${quantity} trips, it'll take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )} to finish. Removed ${quantityWealths}x Ring of wealth from your bank.${
 		hasDiary ? ' 3x Boost for Wilderness Elite diary.' : ''
 	}`;
 }

--- a/src/mahoji/lib/abstracted_commands/collectCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/collectCommand.ts
@@ -4,7 +4,7 @@ import { Bank } from 'oldschooljs';
 import { WildernessDiary, userhasDiaryTier } from '../../../lib/diaries';
 import type { SkillsEnum } from '../../../lib/skilling/types';
 import type { CollectingOptions } from '../../../lib/types/minions';
-import { formatDuration, stringMatches } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
@@ -93,9 +93,9 @@ export async function collectCommand(
 		type: 'Collecting'
 	});
 
-	return `${user.minionName} is now collecting ${quantity * collectable.quantity}x ${
-		collectable.item.name
-	}, it'll take around ${formatDuration(duration)} to finish.${
+       return `${user.minionName} is now collecting ${quantity * collectable.quantity}x ${
+               collectable.item.name
+       }, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.${
 		cost.toString().length > 0
 			? `
 Removed ${cost} from your bank.`

--- a/src/mahoji/lib/abstracted_commands/cutLeapingFishCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/cutLeapingFishCommand.ts
@@ -3,7 +3,7 @@ import { Bank } from 'oldschooljs';
 
 import LeapingFish from '../../../lib/skilling/skills/cooking/leapingFish';
 import type { CutLeapingFishActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, stringMatches } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 
@@ -72,7 +72,7 @@ export async function cutLeapingFishCommand({
 		type: 'CutLeapingFish'
 	});
 
-	return `${user.minionName} is now cutting ${quantity}x ${
-		barbarianFish.item.name
-	}, it'll take around ${formatDuration(duration)} to finish.`;
+       return `${user.minionName} is now cutting ${quantity}x ${
+               barbarianFish.item.name
+       }, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.`;
 }

--- a/src/mahoji/lib/abstracted_commands/driftNetCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/driftNetCommand.ts
@@ -1,7 +1,7 @@
 import { Time, randFloat, reduceNumByPercent } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { ActivityTaskOptionsWithQuantity } from '../../../lib/types/minions';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
@@ -86,7 +86,7 @@ export async function driftNetCommand(
 
 	await user.removeItemsFromBank(itemsToRemove);
 
-	let str = `${user.minionName} is now doing Drift net fishing, it will take around ${formatDuration(duration)}.`;
+       let str = `${user.minionName} is now doing Drift net fishing, it will take around ${formatDurationWithTimestamp(duration, user.perkTier())}.`;
 
 	if (itemsToRemove.length > 0) {
 		str += ` Removed ${itemsToRemove} from your bank.`;

--- a/src/mahoji/lib/abstracted_commands/enchantCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/enchantCommand.ts
@@ -3,7 +3,7 @@ import { Time } from 'e';
 import { Enchantables } from '../../../lib/skilling/skills/magic/enchantables';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { EnchantingActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, itemNameFromID, stringMatches } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, itemNameFromID, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { determineRunes } from '../../../lib/util/determineRunes';
@@ -70,7 +70,8 @@ export async function enchantCommand(user: MUser, channelID: string, name: strin
 
 	const xpHr = `${Math.round(((enchantable.xp * quantity) / (duration / Time.Minute)) * 60).toLocaleString()} XP/Hr`;
 
-	return `${user.minionName} is now enchanting ${quantity}x ${enchantable.name}, it'll take around ${formatDuration(
-		duration
-	)} to finish. Removed ${cost} from your bank. ${xpHr}`;
+       return `${user.minionName} is now enchanting ${quantity}x ${enchantable.name}, it'll take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )} to finish. Removed ${cost} from your bank. ${xpHr}`;
 }

--- a/src/mahoji/lib/abstracted_commands/fishingTrawler.ts
+++ b/src/mahoji/lib/abstracted_commands/fishingTrawler.ts
@@ -1,6 +1,6 @@
 import { Time, calcWhatPercent, reduceNumByPercent } from 'e';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import { getMinigameScore } from '../../../lib/settings/minigames';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
@@ -30,7 +30,8 @@ export async function fishingTrawlerCommand(user: MUser, channelID: string) {
 		duration
 	});
 
-	return `${user.minionName} is now doing ${quantity}x Fishing Trawler trips, it will take around ${formatDuration(
-		duration
-	)} to finish.\n\n**Boosts:** ${boost}% boost for experience`;
+       return `${user.minionName} is now doing ${quantity}x Fishing Trawler trips, it will take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )} to finish.\n\n**Boosts:** ${boost}% boost for experience`;
 }

--- a/src/mahoji/lib/abstracted_commands/forestersRationCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/forestersRationCommand.ts
@@ -3,7 +3,7 @@ import { Bank } from 'oldschooljs';
 
 import ForestryRations from '../../../lib/skilling/skills/cooking/forestersRations';
 import type { CreateForestersRationsActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, stringMatches } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 
@@ -71,7 +71,7 @@ export async function forestersRationCommand({
 		type: 'CreateForestersRations'
 	});
 
-	return `${user.minionName} is now creating ${quantity}x ${
-		forestryFood.name
-	}, it'll take around ${formatDuration(duration)} to finish.`;
+       return `${user.minionName} is now creating ${quantity}x ${
+               forestryFood.name
+       }, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.`;
 }

--- a/src/mahoji/lib/abstracted_commands/mageTrainingArenaCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/mageTrainingArenaCommand.ts
@@ -4,7 +4,7 @@ import { Bank, LootTable } from 'oldschooljs';
 
 import { getNewUser } from '../../../lib/settings/settings';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, stringMatches } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { determineRunes } from '../../../lib/util/determineRunes';
@@ -142,9 +142,10 @@ export async function mageTrainingArenaStartCommand(user: MUser, channelID: stri
 		minigameID: 'magic_training_arena'
 	});
 
-	return `${
-		user.minionName
-	} is now doing ${quantity} Magic Training Arena rooms. The trip will take around ${formatDuration(
-		duration
-	)}. Removed ${cost} from your bank.`;
+       return `${
+               user.minionName
+       } is now doing ${quantity} Magic Training Arena rooms. The trip will take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )}. Removed ${cost} from your bank.`;
 }

--- a/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/minionKill.ts
@@ -7,7 +7,7 @@ import { trackLoot } from '../../../../lib/lootTrack';
 import { revenantMonsters } from '../../../../lib/minions/data/killableMonsters/revs';
 import { getUsersCurrentSlayerInfo } from '../../../../lib/slayer/slayerUtil';
 import type { MonsterActivityTaskOptions } from '../../../../lib/types/minions';
-import { formatDuration, stringMatches } from '../../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, stringMatches } from '../../../../lib/util';
 import addSubTaskToActivityTask from '../../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../../lib/util/calcMaxTripLength';
 import findMonster from '../../../../lib/util/findMonster';
@@ -142,9 +142,10 @@ export async function minionKillCommand(
 		attackStyles: result.attackStyles,
 		onTask: slayerInfo.assignedTask !== null
 	});
-	let response = `${minionName} is now killing ${result.quantity}x ${monster.name}, it'll take around ${formatDuration(
-		result.duration
-	)} to finish. Attack styles used: ${result.attackStyles.join(', ')}.`;
+       let response = `${minionName} is now killing ${result.quantity}x ${monster.name}, it'll take around ${formatDurationWithTimestamp(
+               result.duration,
+               user.perkTier()
+       )} to finish. Attack styles used: ${result.attackStyles.join(', ')}.`;
 
 	if (result.messages.length > 0) {
 		response += `\n\n${result.messages.join(', ')}`;

--- a/src/mahoji/lib/abstracted_commands/motherlodeMineCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/motherlodeMineCommand.ts
@@ -5,7 +5,7 @@ import { determineMiningTime } from '../../../lib/skilling/functions/determineMi
 import { pickaxes } from '../../../lib/skilling/functions/miningBoosts';
 import Mining from '../../../lib/skilling/skills/mining';
 import type { MotherlodeMiningActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, itemNameFromID } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, itemNameFromID } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { minionName } from '../../../lib/util/minionUtils';
@@ -92,11 +92,11 @@ export async function motherlodeMineCommand({
 	});
 	let response = `${minionName(user)} is now mining at the Motherlode Mine until your minion ${
 		quantity ? `mined ${quantity}x pay-dirt or gets tired` : 'is satisfied'
-	}, it'll take ${
-		quantity
-			? `between ${formatDuration(fakeDurationMin)} **and** ${formatDuration(fakeDurationMax)}`
-			: formatDuration(duration)
-	} to finish.`;
+       }, it'll take ${
+               quantity
+                       ? `between ${formatDurationWithTimestamp(fakeDurationMin, user.perkTier())} **and** ${formatDurationWithTimestamp(fakeDurationMax, user.perkTier())}`
+                       : formatDurationWithTimestamp(duration, user.perkTier())
+       } to finish.`;
 
 	if (boosts.length > 0) {
 		response += `\n\n**Boosts:** ${boosts.join(', ')}.`;

--- a/src/mahoji/lib/abstracted_commands/myNotesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/myNotesCommand.ts
@@ -2,7 +2,7 @@ import { Time } from 'e';
 
 import removeFoodFromUser from '../../../lib/minions/functions/removeFoodFromUser';
 import type { ActivityTaskOptionsWithQuantity } from '../../../lib/types/minions';
-import { formatDuration } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 
@@ -31,9 +31,10 @@ export async function myNotesCommand(user: MUser, channelID: string) {
 		quantity
 	});
 
-	return `${
-		user.minionName
-	} is now rummaging ${quantity} skeletons for Ancient pages, it'll take around ${formatDuration(
-		duration
-	)} to finish. Removed ${foodRemoved}.`;
+       return `${
+               user.minionName
+       } is now rummaging ${quantity} skeletons for Ancient pages, it'll take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )} to finish. Removed ${foodRemoved}.`;
 }

--- a/src/mahoji/lib/abstracted_commands/ouraniaAltarCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/ouraniaAltarCommand.ts
@@ -4,7 +4,7 @@ import { Bank } from 'oldschooljs';
 import Runecraft from '../../../lib/skilling/skills/runecraft';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { OuraniaAltarOptions } from '../../../lib/types/minions';
-import { formatDuration, itemID } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, itemID } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
@@ -139,9 +139,10 @@ export async function ouraniaAltarStartCommand({
 		response += ' Pure ';
 	}
 
-	response += `Essence at the Ourania Altar, it'll take around ${formatDuration(
-		duration
-	)} to finish, this will take ${numberOfInventories}x trips to the altar.\nYour minion has consumed: ${itemCost}.\n\n**Boosts:** ${boosts.join(
+       response += `Essence at the Ourania Altar, it'll take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )} to finish, this will take ${numberOfInventories}x trips to the altar.\nYour minion has consumed: ${itemCost}.\n\n**Boosts:** ${boosts.join(
 		', '
 	)}`;
 

--- a/src/mahoji/lib/abstracted_commands/scatterCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/scatterCommand.ts
@@ -4,7 +4,7 @@ import { Bank } from 'oldschooljs';
 import Prayer from '../../../lib/skilling/skills/prayer';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { ScatteringActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, stringMatches } from '../../../lib/util';
+import { formatDuration, formatDurationWithTimestamp, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 
@@ -60,5 +60,5 @@ export async function scatterCommand(user: MUser, channelID: string, ashName: st
 		type: 'Scattering'
 	});
 
-	return `${user.minionName} is now scattering ${cost}, it'll take around ${formatDuration(duration)} to finish.`;
+       return `${user.minionName} is now scattering ${cost}, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.`;
 }

--- a/src/mahoji/lib/abstracted_commands/tiaraRunecraftCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/tiaraRunecraftCommand.ts
@@ -2,7 +2,7 @@ import { Time } from 'e';
 import { Bank } from 'oldschooljs';
 import { SkillsEnum } from 'oldschooljs/dist/constants';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import Runecraft from '../../../lib/skilling/skills/runecraft';
 import type { TiaraRunecraftActivityTaskOptions } from '../../../lib/types/minions';
 import { stringMatches } from '../../../lib/util';
@@ -106,9 +106,9 @@ export async function tiaraRunecraftCommand({
 		type: 'TiaraRunecraft'
 	});
 
-	let response = `${user.minionName} is now turning ${quantity}x Tiaras into ${
-		tiaraObj.name
-	}s, it'll take around ${formatDuration(duration)} to finish.`;
+       let response = `${user.minionName} is now turning ${quantity}x Tiaras into ${
+               tiaraObj.name
+       }s, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.`;
 
 	if (boosts.length > 0) response += `\n\n**Boosts:** ${boosts.join(', ')}`;
 

--- a/src/mahoji/lib/abstracted_commands/underwaterCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/underwaterCommand.ts
@@ -1,7 +1,7 @@
 import { Time, randFloat, reduceNumByPercent } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import type { UnderwaterAgilityThievingTrainingSkill } from '../../../lib/constants';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
@@ -88,9 +88,10 @@ export async function underwaterAgilityThievingCommand(
 
 	await user.removeItemsFromBank(itemsToRemove);
 
-	let str = `${user.minionName} is now doing Underwater Agility and Thieving, it will take around ${formatDuration(
-		duration
-	)}.`;
+       let str = `${user.minionName} is now doing Underwater Agility and Thieving, it will take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )}.`;
 
 	if (itemsToRemove.length > 0) {
 		str += ` Removed ${itemsToRemove} from your bank.`;

--- a/src/mahoji/lib/abstracted_commands/warriorsGuildCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/warriorsGuildCommand.ts
@@ -1,7 +1,7 @@
 import { Time } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+import { formatDuration, formatDurationWithTimestamp } from '@oldschoolgg/toolkit/util';
 import { resolveItems } from 'oldschooljs/dist/util/util';
 import type { ActivityTaskOptionsWithQuantity, AnimatedArmourActivityTaskOptions } from '../../../lib/types/minions';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
@@ -68,9 +68,9 @@ async function tokensCommand(user: MUser, channelID: string, quantity: number | 
 		type: 'AnimatedArmour'
 	});
 
-	const response = `${user.minionName} is now killing ${quantity}x animated ${
-		armorSet.name
-	} armour, it'll take around ${formatDuration(duration)} to finish.`;
+       const response = `${user.minionName} is now killing ${quantity}x animated ${
+               armorSet.name
+       } armour, it'll take around ${formatDurationWithTimestamp(duration, user.perkTier())} to finish.`;
 
 	return response;
 }
@@ -120,9 +120,10 @@ async function cyclopsCommand(user: MUser, channelID: string, quantity: number |
 		type: 'Cyclops'
 	});
 
-	const response = `${user.minionName} is now off to kill ${quantity}x Cyclops, it'll take around ${formatDuration(
-		duration
-	)} to finish. ${
+       const response = `${user.minionName} is now off to kill ${quantity}x Cyclops, it'll take around ${formatDurationWithTimestamp(
+               duration,
+               user.perkTier()
+       )} to finish. ${
 		hasAttackCape
 			? 'You used no warrior guild tokens because you have an Attack cape.'
 			: `Removed ${tokensToSpend} Warrior guild tokens from your bank.`


### PR DESCRIPTION
## Summary
- add `formatDurationWithTimestamp` helper
- export the helper through util package
- show return timestamps for perk tier 4+ users in many trip start messages

## Testing
- `npm test` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480a7f12808326bbc281711e2fa6ff