### PR TITLE
Remove unused formatDuration imports

### DIFF
--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -9,7 +9,7 @@ import { BitField } from '../../lib/constants';
 import { determineWoodcuttingTime } from '../../lib/skilling/functions/determineWoodcuttingTime';
 import Woodcutting from '../../lib/skilling/skills/woodcutting/woodcutting';
 import type { WoodcuttingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, itemNameFromID, randomVariation, stringMatches } from '../../lib/util';
+import { formatDurationFromUser, itemNameFromID, randomVariation, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import itemID from '../../lib/util/itemID';
 import { minionName } from '../../lib/util/minionUtils';

--- a/src/mahoji/lib/abstracted_commands/aerialFishingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/aerialFishingCommand.ts
@@ -3,7 +3,7 @@ import { Time } from 'e';
 import { BitField } from '../../../lib/constants';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { ActivityTaskOptionsWithQuantity } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 

--- a/src/mahoji/lib/abstracted_commands/agilityArenaCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/agilityArenaCommand.ts
@@ -5,7 +5,7 @@ import { Time } from 'e';
 import { KaramjaDiary, userhasDiaryTier } from '../../../lib/diaries';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { mahojiChatHead } from '../../../lib/util/chatHeadImage';

--- a/src/mahoji/lib/abstracted_commands/birdhousesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/birdhousesCommand.ts
@@ -6,7 +6,7 @@ import birdhouses, { birdhouseSeeds } from '../../../lib/skilling/skills/hunter/
 import type { BirdhouseData } from '../../../lib/skilling/skills/hunter/defaultBirdHouseTrap';
 import defaultBirdhouseTrap from '../../../lib/skilling/skills/hunter/defaultBirdHouseTrap';
 import type { BirdhouseActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
 import { mahojiUsersSettingsFetch, userHasGracefulEquipped } from '../../mahojiSettings';

--- a/src/mahoji/lib/abstracted_commands/castleWarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/castleWarsCommand.ts
@@ -1,6 +1,5 @@
 import { Time } from 'e';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
 import { BitField } from '../../../lib/constants';
 import { getMinigameEntity } from '../../../lib/settings/settings';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';

--- a/src/mahoji/lib/abstracted_commands/coxCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/coxCommand.ts
@@ -21,7 +21,7 @@ import { setupParty } from '../../../lib/party';
 import { getMinigameScore } from '../../../lib/settings/minigames';
 import type { MakePartyOptions } from '../../../lib/types';
 import type { RaidsOptions } from '../../../lib/types/minions';
-import { channelIsSendable, formatDuration, formatDurationFromUser, randomVariation } from '../../../lib/util';
+import { channelIsSendable, formatDurationFromUser, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';

--- a/src/mahoji/lib/abstracted_commands/gnomeRestaurantCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/gnomeRestaurantCommand.ts
@@ -5,7 +5,7 @@ import { SkillsEnum } from 'oldschooljs/dist/constants';
 import { getPOHObject } from '../../../lib/poh';
 import { getMinigameScore } from '../../../lib/settings/minigames';
 import type { GnomeRestaurantActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';

--- a/src/mahoji/lib/abstracted_commands/guardiansOfTheRiftCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/guardiansOfTheRiftCommand.ts
@@ -6,7 +6,7 @@ import { pickaxes, varrockArmours } from '../../../lib/skilling/functions/mining
 import Runecraft from '../../../lib/skilling/skills/runecraft';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { GuardiansOfTheRiftActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, itemID, itemNameFromID, randomVariation } from '../../../lib/util';
+import { formatDurationFromUser, itemID, itemNameFromID, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { determineRunes } from '../../../lib/util/determineRunes';

--- a/src/mahoji/lib/abstracted_commands/lmsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/lmsCommand.ts
@@ -5,7 +5,7 @@ import { Bank } from 'oldschooljs';
 import { LMSBuyables } from '../../../lib/data/CollectionsExport';
 import { lmsSimCommand } from '../../../lib/minions/functions/lmsSimCommand';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';

--- a/src/mahoji/lib/abstracted_commands/mageArena2Command.ts
+++ b/src/mahoji/lib/abstracted_commands/mageArena2Command.ts
@@ -4,7 +4,7 @@ import { SkillsEnum } from 'oldschooljs/dist/constants';
 
 import removeFoodFromUser from '../../../lib/minions/functions/removeFoodFromUser';
 import type { ActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
 

--- a/src/mahoji/lib/abstracted_commands/mageArenaCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/mageArenaCommand.ts
@@ -4,7 +4,7 @@ import { SkillsEnum } from 'oldschooljs/dist/constants';
 
 import removeFoodFromUser from '../../../lib/minions/functions/removeFoodFromUser';
 import type { ActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
 

--- a/src/mahoji/lib/abstracted_commands/mahoganyHomesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/mahoganyHomesCommand.ts
@@ -6,7 +6,7 @@ import { getMinigameScore } from '../../../lib/settings/minigames';
 import { Plank } from '../../../lib/skilling/skills/construction/constructables';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { MahoganyHomesActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';

--- a/src/mahoji/lib/abstracted_commands/motherlodeMineCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/motherlodeMineCommand.ts
@@ -6,7 +6,7 @@ import { determineMiningTime } from '../../../lib/skilling/functions/determineMi
 import { pickaxes } from '../../../lib/skilling/functions/miningBoosts';
 import Mining from '../../../lib/skilling/skills/mining';
 import type { MotherlodeMiningActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, itemNameFromID } from '../../../lib/util';
+import { formatDurationFromUser, itemNameFromID } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { minionName } from '../../../lib/util/minionUtils';

--- a/src/mahoji/lib/abstracted_commands/nexCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nexCommand.ts
@@ -6,7 +6,7 @@ import { trackLoot } from '../../../lib/lootTrack';
 import { setupParty } from '../../../lib/party';
 import { calculateNexDetails, checkNexUser } from '../../../lib/simulation/nex';
 import type { NexTaskOptions } from '../../../lib/types/minions';
-import { calcPerHour, formatDuration, formatDurationFromUser } from '../../../lib/util';
+import { calcPerHour, formatDurationFromUser } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { deferInteraction } from '../../../lib/util/interactionReply';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';

--- a/src/mahoji/lib/abstracted_commands/nightmareZoneCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nightmareZoneCommand.ts
@@ -9,7 +9,7 @@ import { resolveAttackStyles } from '../../../lib/minions/functions';
 import { getMinigameEntity } from '../../../lib/settings/minigames';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { Skills } from '../../../lib/types';
-import { formatDuration, formatDurationFromUser, hasSkillReqs, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, hasSkillReqs, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';

--- a/src/mahoji/lib/abstracted_commands/pestControlCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/pestControlCommand.ts
@@ -7,7 +7,7 @@ import { WesternProv, userhasDiaryTier } from '../../../lib/diaries';
 import { getMinigameScore } from '../../../lib/settings/settings';
 import type { SkillsEnum } from '../../../lib/skilling/types';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, hasSkillReqs, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, hasSkillReqs, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';

--- a/src/mahoji/lib/abstracted_commands/puroPuroCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/puroPuroCommand.ts
@@ -3,7 +3,7 @@ import { Time } from 'e';
 import type { Item } from 'oldschooljs';
 import type { Skills } from '../../../lib/types';
 import type { PuroPuroActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, hasSkillReqs, itemID, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, hasSkillReqs, itemID, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';

--- a/src/mahoji/lib/abstracted_commands/questCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/questCommand.ts
@@ -1,6 +1,5 @@
 import { Time, sumArr } from 'e';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
 import { MAX_GLOBAL_QP, MAX_QP, quests } from '../../../lib/minions/data/quests';
 import type { ActivityTaskOptionsWithNoChanges, SpecificQuestOptions } from '../../../lib/types/minions';
 import { formatDurationFromUser } from '../../../lib/util';

--- a/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
@@ -10,7 +10,7 @@ import { pickaxes } from '../../../lib/skilling/functions/miningBoosts';
 import type { Ore } from '../../../lib/skilling/types';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { ActivityTaskData, ShootingStarsOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, itemNameFromID } from '../../../lib/util';
+import { formatDurationFromUser, itemNameFromID } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength, patronMaxTripBonus } from '../../../lib/util/calcMaxTripLength';
 import { minionName } from '../../../lib/util/minionUtils';

--- a/src/mahoji/lib/abstracted_commands/soulWarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/soulWarsCommand.ts
@@ -3,7 +3,7 @@ import { Time } from 'e';
 import { Bank } from 'oldschooljs';
 
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';

--- a/src/mahoji/lib/abstracted_commands/volcanicMineCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/volcanicMineCommand.ts
@@ -2,7 +2,6 @@ import type { ChatInputCommandInteraction } from 'discord.js';
 import { Time, objectEntries } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
 import { getMinigameScore } from '../../../lib/settings/minigames';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { ActivityTaskOptionsWithQuantity } from '../../../lib/types/minions';


### PR DESCRIPTION
## Summary
- clean up unused `formatDuration` imports
- keep linting happy

## Testing
- `pnpm lint`
- `pnpm dev` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68487f823dd4832689f70480009c72ea