### PR TITLE
Use user bitfield when formatting durations

### DIFF
--- a/src/mahoji/commands/build.ts
+++ b/src/mahoji/commands/build.ts
@@ -9,7 +9,7 @@ import { BitField } from '../../lib/constants';
 import Constructables from '../../lib/skilling/skills/construction/constructables';
 import type { Skills } from '../../lib/types';
 import type { ConstructionActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, hasSkillReqs } from '../../lib/util';
+import { formatDurationFromUser, hasSkillReqs } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
@@ -121,13 +121,14 @@ export const buildCommand: OSBMahojiCommand = {
 
 		const duration = quantity * timeToBuildSingleObject;
 
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)} minutes, try a lower quantity. The highest amount of ${object.name}s you can build is ${Math.floor(
-				maxTripLength / timeToBuildSingleObject
-			)}.`;
-		}
+                if (duration > maxTripLength) {
+                        return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )} minutes, try a lower quantity. The highest amount of ${object.name}s you can build is ${Math.floor(
+                                maxTripLength / timeToBuildSingleObject
+                        )}.`;
+                }
 
 		const gpNeeded = Math.floor(10_000 * (invsPerTrip / 8));
 		cost.add('Coins', gpNeeded);

--- a/src/mahoji/commands/chop.ts
+++ b/src/mahoji/commands/chop.ts
@@ -9,7 +9,7 @@ import { BitField } from '../../lib/constants';
 import { determineWoodcuttingTime } from '../../lib/skilling/functions/determineWoodcuttingTime';
 import Woodcutting from '../../lib/skilling/skills/woodcutting/woodcutting';
 import type { WoodcuttingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, itemNameFromID, randomVariation, stringMatches } from '../../lib/util';
+import { formatDurationFromUser, itemNameFromID, randomVariation, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import itemID from '../../lib/util/itemID';
 import { minionName } from '../../lib/util/minionUtils';

--- a/src/mahoji/commands/clue.ts
+++ b/src/mahoji/commands/clue.ts
@@ -11,7 +11,7 @@ import { allOpenables, getOpenableLoot } from '../../lib/openables';
 import { getPOHObject } from '../../lib/poh';
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { ClueActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, isWeekend, stringMatches } from '../../lib/util';
+import { formatDurationFromUser, isWeekend, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { getItem } from '../../lib/util/getOSItem';
@@ -433,11 +433,12 @@ export const clueCommand: OSBMahojiCommand = {
 		}
 
 		const duration = timePerClue * quantity;
-		if (duration > maxTripLength || quantity > maxCanDo) {
-			return `${user.minionName} can't go on Clue trips longer than ${formatDuration(
-				maxTripLength
-			)}, try a lower quantity. The highest amount you can do for ${clueTier.name} is ${maxCanDo}.`;
-		}
+                if (duration > maxTripLength || quantity > maxCanDo) {
+                        return `${user.minionName} can't go on Clue trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )}, try a lower quantity. The highest amount you can do for ${clueTier.name} is ${maxCanDo}.`;
+                }
 
 		await addSubTaskToActivityTask<ClueActivityTaskOptions>({
 			ci: clueTier.id,

--- a/src/mahoji/commands/cook.ts
+++ b/src/mahoji/commands/cook.ts
@@ -9,7 +9,7 @@ import Cooking, { Cookables } from '../../lib/skilling/skills/cooking/cooking';
 import ForestryRations from '../../lib/skilling/skills/cooking/forestersRations';
 import LeapingFish from '../../lib/skilling/skills/cooking/leapingFish';
 import type { CookingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, itemID, stringMatches } from '../../lib/util';
+import { formatDurationFromUser, itemID, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { cutLeapingFishCommand } from '../lib/abstracted_commands/cutLeapingFishCommand';
@@ -132,13 +132,14 @@ export const cookCommand: OSBMahojiCommand = {
 
 		const duration = quantity * timeToCookSingleCookable;
 
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)} minutes, try a lower quantity. The highest amount of ${cookable.name}s you can cook is ${Math.floor(
-				maxTripLength / timeToCookSingleCookable
-			)}.`;
-		}
+                if (duration > maxTripLength) {
+                        return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )} minutes, try a lower quantity. The highest amount of ${cookable.name}s you can cook is ${Math.floor(
+                                maxTripLength / timeToCookSingleCookable
+                        )}.`;
+                }
 
 		await user.removeItemsFromBank(totalCost);
 
@@ -151,10 +152,9 @@ export const cookCommand: OSBMahojiCommand = {
 			type: 'Cooking'
 		});
 
-		return `${user.minionName} is now cooking ${quantity}x ${cookable.name}, it'll take around ${formatDurationFromUser(
-			duration,
-			user.perkTier(),
-			user.bitfield.includes(BitField.ShowMinionReturnTime)
-		)} to finish.${boosts.length > 0 ? `\n\nBoosts: ${boosts.join(', ')}` : ''}`;
+                return `${user.minionName} is now cooking ${quantity}x ${cookable.name}, it'll take around ${formatDurationFromUser(
+                        duration,
+                        user
+                )} to finish.${boosts.length > 0 ? `\n\nBoosts: ${boosts.join(', ')}` : ''}`;
 	}
 };

--- a/src/mahoji/commands/fletch.ts
+++ b/src/mahoji/commands/fletch.ts
@@ -3,7 +3,7 @@ import type { CommandRunOptions } from '@oldschoolgg/toolkit/util';
 import { ApplicationCommandOptionType } from 'discord.js';
 import { Time } from 'e';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+
 import { BitField } from '../../lib/constants';
 import Fletching from '../../lib/skilling/skills/fletching';
 import { Fletchables } from '../../lib/skilling/skills/fletching/fletchables';
@@ -90,13 +90,14 @@ export const fletchCommand: OSBMahojiCommand = {
 		}
 
 		const duration = quantity * timeToFletchSingleItem;
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)}, try a lower quantity. The highest amount of ${fletchable.name}s you can fletch is ${Math.floor(
-				maxTripLength / timeToFletchSingleItem
-			)}.`;
-		}
+                if (duration > maxTripLength) {
+                        return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )}, try a lower quantity. The highest amount of ${fletchable.name}s you can fletch is ${Math.floor(
+                                maxTripLength / timeToFletchSingleItem
+                        )}.`;
+                }
 
 		const itemsNeeded = fletchable.inputItems.clone().multiply(quantity);
 		if (!userBank.has(itemsNeeded)) {

--- a/src/mahoji/commands/hunt.ts
+++ b/src/mahoji/commands/hunt.ts
@@ -13,7 +13,7 @@ import Hunter from '../../lib/skilling/skills/hunter/hunter';
 import { HunterTechniqueEnum, SkillsEnum } from '../../lib/skilling/types';
 import type { Peak } from '../../lib/tickers';
 import type { HunterActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, hasSkillReqs, itemID } from '../../lib/util';
+import { formatDurationFromUser, hasSkillReqs, itemID } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
@@ -186,13 +186,14 @@ export const huntCommand: OSBMahojiCommand = {
 			duration = Math.floor(quantity * Time.Minute);
 		}
 
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)}, try a lower quantity. The highest amount of ${creature.name} you can hunt is ${Math.floor(
-				maxTripLength / ((catchTime * Time.Second) / traps)
-			)}.`;
-		}
+                if (duration > maxTripLength) {
+                        return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )}, try a lower quantity. The highest amount of ${creature.name} you can hunt is ${Math.floor(
+                                maxTripLength / ((catchTime * Time.Second) / traps)
+                        )}.`;
+                }
 
 		const removeBank = new Bank();
 

--- a/src/mahoji/commands/laps.ts
+++ b/src/mahoji/commands/laps.ts
@@ -8,7 +8,7 @@ import { quests } from '../../lib/minions/data/quests';
 import { courses } from '../../lib/skilling/skills/agility';
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { AgilityActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, stringMatches } from '../../lib/util';
+import { formatDurationFromUser, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
@@ -153,13 +153,14 @@ export const lapsCommand: OSBMahojiCommand = {
 		}
 		const duration = quantity * timePerLap;
 
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)}, try a lower quantity. The highest amount of ${course.name} laps you can do is ${Math.floor(
-				maxTripLength / timePerLap
-			)}.`;
-		}
+                if (duration > maxTripLength) {
+                        return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )}, try a lower quantity. The highest amount of ${course.name} laps you can do is ${Math.floor(
+                                maxTripLength / timePerLap
+                        )}.`;
+                }
 
 		let response = `${user.minionName} is now doing ${quantity}x ${
 			course.name

--- a/src/mahoji/commands/light.ts
+++ b/src/mahoji/commands/light.ts
@@ -4,7 +4,7 @@ import { ApplicationCommandOptionType } from 'discord.js';
 import { Time } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+
 import { BitField } from '../../lib/constants';
 import Firemaking from '../../lib/skilling/skills/firemaking';
 import { SkillsEnum } from '../../lib/skilling/types';
@@ -75,13 +75,14 @@ export const lightCommand: OSBMahojiCommand = {
 		const cost = new Bank().add(log.inputLogs, quantity);
 		if (!user.owns(cost)) return `You dont have ${quantity}x ${log.name}.`;
 
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)}, try a lower quantity. The highest amount of ${log.name}s you can light is ${Math.floor(
-				maxTripLength / timeToLightSingleLog
-			)}.`;
-		}
+                if (duration > maxTripLength) {
+                        return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )}, try a lower quantity. The highest amount of ${log.name}s you can light is ${Math.floor(
+                                maxTripLength / timeToLightSingleLog
+                        )}.`;
+                }
 
 		await transactItems({ userID: user.id, itemsToRemove: cost });
 
@@ -94,10 +95,9 @@ export const lightCommand: OSBMahojiCommand = {
 			type: 'Firemaking'
 		});
 
-		return `${user.minionName} is now lighting ${quantity}x ${log.name}, it'll take around ${formatDurationFromUser(
-			duration,
-			user.perkTier(),
-			user.bitfield.includes(BitField.ShowMinionReturnTime)
-		)} to finish.`;
+                return `${user.minionName} is now lighting ${quantity}x ${log.name}, it'll take around ${formatDurationFromUser(
+                        duration,
+                        user
+                )} to finish.`;
 	}
 };

--- a/src/mahoji/commands/mass.ts
+++ b/src/mahoji/commands/mass.ts
@@ -10,7 +10,7 @@ import removeFoodFromUser from '../../lib/minions/functions/removeFoodFromUser';
 import type { KillableMonster } from '../../lib/minions/types';
 import { setupParty } from '../../lib/party';
 import type { GroupMonsterActivityTaskOptions } from '../../lib/types/minions';
-import { channelIsSendable, formatDuration, formatDurationFromUser } from '../../lib/util';
+import { channelIsSendable, formatDurationFromUser } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import calcDurQty from '../../lib/util/calcMassDurationQuantity';
 import findMonster from '../../lib/util/findMonster';
@@ -171,14 +171,15 @@ export const massCommand: OSBMahojiCommand = {
 		if (boostMsgs.length > 0) {
 			killsPerHr += `\n\n${boostMsgs.join(', ')}.`;
 		}
-		let str = `${user.usernameOrMention}'s party (${users
-			.map(u => u.usernameOrMention)
-			.join(', ')}) is now off to kill ${quantity}x ${monster.name}. Each kill takes ${formatDuration(
-			perKillTime
-		)} instead of ${formatDuration(monster.timeToFinish)}- the total trip will take ${formatDurationFromUser(
-			duration,
-			user
-		)}. ${killsPerHr}`;
+                let str = `${user.usernameOrMention}'s party (${users
+                        .map(u => u.usernameOrMention)
+                        .join(', ')}) is now off to kill ${quantity}x ${monster.name}. Each kill takes ${formatDurationFromUser(
+                        perKillTime,
+                        user
+                )} instead of ${formatDurationFromUser(monster.timeToFinish, user)}- the total trip will take ${formatDurationFromUser(
+                        duration,
+                        user
+                )}. ${killsPerHr}`;
 
 		if (usersKickedForBusy.length > 0) {
 			str += `\nThe following users were removed, because their minion became busy before the mass started: ${usersKickedForBusy

--- a/src/mahoji/commands/offer.ts
+++ b/src/mahoji/commands/offer.ts
@@ -5,7 +5,6 @@ import { ApplicationCommandOptionType } from 'discord.js';
 import { Time, randArrItem, randInt, roll } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
 import { resolveItems } from 'oldschooljs/dist/util/util';
 import { BitField, Events } from '../../lib/constants';
 import { evilChickenOutfit } from '../../lib/data/CollectionsExport';
@@ -265,13 +264,14 @@ export const offerCommand: OSBMahojiCommand = {
 
 		const duration = quantity * timeToBuryABone;
 
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)}, try a lower quantity. The highest amount of ${bone.name}s you can bury is ${Math.floor(
-				maxTripLength / timeToBuryABone
-			)}.`;
-		}
+                if (duration > maxTripLength) {
+                        return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )}, try a lower quantity. The highest amount of ${bone.name}s you can bury is ${Math.floor(
+                                maxTripLength / timeToBuryABone
+                        )}.`;
+                }
 
 		await user.removeItemsFromBank(new Bank().add(bone.inputId, quantity));
 

--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -10,7 +10,7 @@ import { darkAltarCommand } from '../../lib/minions/functions/darkAltarCommand';
 import { sinsOfTheFatherSkillRequirements } from '../../lib/skilling/functions/questRequirements';
 import Runecraft from '../../lib/skilling/skills/runecraft';
 import type { RunecraftActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, formatSkillRequirements, itemID, stringMatches } from '../../lib/util';
+import { formatDurationFromUser, formatSkillRequirements, itemID, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { determineRunes } from '../../lib/util/determineRunes';
@@ -235,11 +235,12 @@ export const runecraftCommand: OSBMahojiCommand = {
 		const numberOfInventories = Math.max(Math.ceil(quantity / inventorySize), 1);
 		let duration = numberOfInventories * tripLength;
 
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)}, try a lower quantity. The highest amount of ${runeObj.name} you can craft is ${Math.floor(maxCanDo)}.`;
-		}
+                if (duration > maxTripLength) {
+                        return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )}, try a lower quantity. The highest amount of ${runeObj.name} you can craft is ${Math.floor(maxCanDo)}.`;
+                }
 
 		if (rune === 'blood') {
 			const hasBloodReqs = user.hasSkillReqs(sinsOfTheFatherSkillRequirements);

--- a/src/mahoji/commands/smelt.ts
+++ b/src/mahoji/commands/smelt.ts
@@ -8,7 +8,7 @@ import { BitField } from '../../lib/constants';
 import Smithing from '../../lib/skilling/skills/smithing';
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { SmeltingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, formatSkillRequirements, itemID, stringMatches } from '../../lib/util';
+import { formatDurationFromUser, formatSkillRequirements, itemID, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
@@ -132,13 +132,14 @@ export const smeltingCommand: OSBMahojiCommand = {
 		cost.add(itemsNeeded.multiply(quantity));
 
 		const duration = quantity * timeToSmithSingleBar;
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)}, try a lower quantity. The highest amount of ${bar.name}s you can smelt is ${Math.floor(
-				maxTripLength / timeToSmithSingleBar
-			)}.`;
-		}
+                if (duration > maxTripLength) {
+                        return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )}, try a lower quantity. The highest amount of ${bar.name}s you can smelt is ${Math.floor(
+                                maxTripLength / timeToSmithSingleBar
+                        )}.`;
+                }
 
 		let coinsToRemove = 0;
 		if (blast_furnace) {

--- a/src/mahoji/commands/smith.ts
+++ b/src/mahoji/commands/smith.ts
@@ -9,7 +9,7 @@ import Smithing from '../../lib/skilling/skills/smithing';
 import smithables from '../../lib/skilling/skills/smithing/smithables';
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { SmithingActivityTaskOptions } from '../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, stringMatches } from '../../lib/util';
+import { formatDurationFromUser, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { pluraliseItemName } from '../../lib/util/smallUtils';
@@ -127,13 +127,14 @@ export const smithCommand: OSBMahojiCommand = {
 		cost.add(baseCost.multiply(quantity));
 
 		const duration = quantity * timeToSmithSingleBar;
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)}, try a lower quantity. The highest amount of ${smithedItem.name}${
-				smithedItem.name.charAt(smithedItem.name.length - 1).toLowerCase() === 's' ? '' : 's'
-			} you can smith is ${Math.floor(maxTripLength / timeToSmithSingleBar)}.`;
-		}
+                if (duration > maxTripLength) {
+                        return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )}, try a lower quantity. The highest amount of ${smithedItem.name}${
+                                smithedItem.name.charAt(smithedItem.name.length - 1).toLowerCase() === 's' ? '' : 's'
+                        } you can smith is ${Math.floor(maxTripLength / timeToSmithSingleBar)}.`;
+                }
 
 		await transactItems({ userID: user.id, itemsToRemove: cost });
 		updateBankSetting('smithing_cost', cost);

--- a/src/mahoji/commands/steal.ts
+++ b/src/mahoji/commands/steal.ts
@@ -4,7 +4,7 @@ import type { User } from 'discord.js';
 import { ApplicationCommandOptionType, bold } from 'discord.js';
 import { randInt } from 'e';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+
 import { BitField } from '../../lib/constants';
 import { ArdougneDiary, userhasDiaryTier } from '../../lib/diaries';
 import { quests } from '../../lib/minions/data/quests';
@@ -121,13 +121,14 @@ export const stealCommand: OSBMahojiCommand = {
 
 		const duration = quantity * timeToTheft;
 
-		if (duration > maxTripLength) {
-			return `${user.minionName} can't go on trips longer than ${formatDuration(
-				maxTripLength
-			)}, try a lower quantity. The highest amount of times you can ${
-				stealable.type === 'pickpockable' ? 'pickpocket' : 'steal from'
-			} a ${stealable.name} is ${Math.floor(maxTripLength / timeToTheft)}.`;
-		}
+                if (duration > maxTripLength) {
+                        return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )}, try a lower quantity. The highest amount of times you can ${
+                                stealable.type === 'pickpockable' ? 'pickpocket' : 'steal from'
+                        } a ${stealable.name} is ${Math.floor(maxTripLength / timeToTheft)}.`;
+                }
 
 		const boosts = [];
 		let successfulQuantity = 0;

--- a/src/mahoji/commands/tokkulshop.ts
+++ b/src/mahoji/commands/tokkulshop.ts
@@ -7,7 +7,7 @@ import { Bank, Monsters } from 'oldschooljs';
 import TokkulShopItems from '../../lib/data/buyables/tokkulBuyables';
 import { KaramjaDiary, userhasDiaryTier } from '../../lib/diaries';
 import type { TokkulShopOptions } from '../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, stringMatches } from '../../lib/util';
+import { formatDurationFromUser, stringMatches } from '../../lib/util';
 import addSubTaskToActivityTask from '../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
 import { handleMahojiConfirmation } from '../../lib/util/handleMahojiConfirmation';
@@ -163,25 +163,27 @@ export const tksCommand: OSBMahojiCommand = {
 		const maxCanTransact = shopStock ? (maxTripLength / Time.Minute) * shopStock : (maxTripLength / 1000) * 50;
 
 		// If the duration of the trip is longer than the users max allowed trip, give the reason why and the max they can buy or sell
-		if (duration > maxTripLength) {
-			return `This trip is too long. You need to ${action} less at a time, to fit your max trip length of ${formatDuration(
-				maxTripLength
-			)}. ${
-				maxCanTransact
-					? `The max ${item.name.toLowerCase()}s you can ${
-							action === 'buy' ? 'buy' : 'sell'
-						} is ${maxCanTransact}`
+                if (duration > maxTripLength) {
+                        return `This trip is too long. You need to ${action} less at a time, to fit your max trip length of ${formatDurationFromUser(
+                                maxTripLength,
+                                user
+                        )}. ${
+                                maxCanTransact
+                                        ? `The max ${item.name.toLowerCase()}s you can ${
+                                                        action === 'buy' ? 'buy' : 'sell'
+                                                } is ${maxCanTransact}`
 					: ''
 			}`;
 		}
 
 		// Confirmation the user has to accept before trip is sent
-		await handleMahojiConfirmation(
-			interaction,
-			`Are you sure you want to spend ${cost} to get ${loot}? The trip to ${action} them will take ${formatDuration(
-				duration
-			)}.`
-		);
+                await handleMahojiConfirmation(
+                        interaction,
+                        `Are you sure you want to spend ${cost} to get ${loot}? The trip to ${action} them will take ${formatDurationFromUser(
+                                duration,
+                                user
+                        )}.`
+                );
 
 		// Remove the cost, and update bank settings
 		await transactItems({ userID: user.id, itemsToRemove: cost });

--- a/src/mahoji/lib/abstracted_commands/aerialFishingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/aerialFishingCommand.ts
@@ -3,7 +3,7 @@ import { Time } from 'e';
 import { BitField } from '../../../lib/constants';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { ActivityTaskOptionsWithQuantity } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 

--- a/src/mahoji/lib/abstracted_commands/agilityArenaCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/agilityArenaCommand.ts
@@ -5,7 +5,7 @@ import { Time } from 'e';
 import { KaramjaDiary, userhasDiaryTier } from '../../../lib/diaries';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { mahojiChatHead } from '../../../lib/util/chatHeadImage';

--- a/src/mahoji/lib/abstracted_commands/birdhousesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/birdhousesCommand.ts
@@ -6,7 +6,7 @@ import birdhouses, { birdhouseSeeds } from '../../../lib/skilling/skills/hunter/
 import type { BirdhouseData } from '../../../lib/skilling/skills/hunter/defaultBirdHouseTrap';
 import defaultBirdhouseTrap from '../../../lib/skilling/skills/hunter/defaultBirdHouseTrap';
 import type { BirdhouseActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
 import { mahojiUsersSettingsFetch, userHasGracefulEquipped } from '../../mahojiSettings';

--- a/src/mahoji/lib/abstracted_commands/castleWarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/castleWarsCommand.ts
@@ -1,6 +1,5 @@
 import { Time } from 'e';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
 import { BitField } from '../../../lib/constants';
 import { getMinigameEntity } from '../../../lib/settings/settings';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';

--- a/src/mahoji/lib/abstracted_commands/coxCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/coxCommand.ts
@@ -21,7 +21,7 @@ import { setupParty } from '../../../lib/party';
 import { getMinigameScore } from '../../../lib/settings/minigames';
 import type { MakePartyOptions } from '../../../lib/types';
 import type { RaidsOptions } from '../../../lib/types/minions';
-import { channelIsSendable, formatDuration, formatDurationFromUser, randomVariation } from '../../../lib/util';
+import { channelIsSendable, formatDurationFromUser, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';

--- a/src/mahoji/lib/abstracted_commands/giantsFoundryCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/giantsFoundryCommand.ts
@@ -8,7 +8,7 @@ import { getMinigameEntity } from '../../../lib/settings/minigames';
 import Smithing from '../../../lib/skilling/skills/smithing';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { GiantsFoundryActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
@@ -200,13 +200,14 @@ export async function giantsFoundryStartCommand(
 		quantity = Math.floor(maxTripLength / (alloy.sections * timePerSection));
 	}
 	const duration = quantity * alloy.sections * timePerSection;
-	if (duration > maxTripLength) {
-		return `${user.minionName} can't go on trips longer than ${formatDuration(
-			maxTripLength
-		)}, try a lower trip length. The highest amount of minutes you can send out is ${Math.floor(
-			maxTripLength / Time.Minute
-		)}.`;
-	}
+        if (duration > maxTripLength) {
+                return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                        maxTripLength,
+                        user
+                )}, try a lower trip length. The highest amount of minutes you can send out is ${Math.floor(
+                        maxTripLength / Time.Minute
+                )}.`;
+        }
 
 	const totalCost = new Bank(alloy.cost).clone().multiply(quantity);
 

--- a/src/mahoji/lib/abstracted_commands/gnomeRestaurantCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/gnomeRestaurantCommand.ts
@@ -5,7 +5,7 @@ import { SkillsEnum } from 'oldschooljs/dist/constants';
 import { getPOHObject } from '../../../lib/poh';
 import { getMinigameScore } from '../../../lib/settings/minigames';
 import type { GnomeRestaurantActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';

--- a/src/mahoji/lib/abstracted_commands/guardiansOfTheRiftCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/guardiansOfTheRiftCommand.ts
@@ -6,7 +6,7 @@ import { pickaxes, varrockArmours } from '../../../lib/skilling/functions/mining
 import Runecraft from '../../../lib/skilling/skills/runecraft';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { GuardiansOfTheRiftActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, itemID, itemNameFromID, randomVariation } from '../../../lib/util';
+import { formatDurationFromUser, itemID, itemNameFromID, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { determineRunes } from '../../../lib/util/determineRunes';

--- a/src/mahoji/lib/abstracted_commands/lmsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/lmsCommand.ts
@@ -5,7 +5,7 @@ import { Bank } from 'oldschooljs';
 import { LMSBuyables } from '../../../lib/data/CollectionsExport';
 import { lmsSimCommand } from '../../../lib/minions/functions/lmsSimCommand';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';

--- a/src/mahoji/lib/abstracted_commands/mageArena2Command.ts
+++ b/src/mahoji/lib/abstracted_commands/mageArena2Command.ts
@@ -4,7 +4,7 @@ import { SkillsEnum } from 'oldschooljs/dist/constants';
 
 import removeFoodFromUser from '../../../lib/minions/functions/removeFoodFromUser';
 import type { ActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
 

--- a/src/mahoji/lib/abstracted_commands/mageArenaCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/mageArenaCommand.ts
@@ -4,7 +4,7 @@ import { SkillsEnum } from 'oldschooljs/dist/constants';
 
 import removeFoodFromUser from '../../../lib/minions/functions/removeFoodFromUser';
 import type { ActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
 

--- a/src/mahoji/lib/abstracted_commands/mahoganyHomesCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/mahoganyHomesCommand.ts
@@ -6,7 +6,7 @@ import { getMinigameScore } from '../../../lib/settings/minigames';
 import { Plank } from '../../../lib/skilling/skills/construction/constructables';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { MahoganyHomesActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';

--- a/src/mahoji/lib/abstracted_commands/motherlodeMineCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/motherlodeMineCommand.ts
@@ -6,7 +6,7 @@ import { determineMiningTime } from '../../../lib/skilling/functions/determineMi
 import { pickaxes } from '../../../lib/skilling/functions/miningBoosts';
 import Mining from '../../../lib/skilling/skills/mining';
 import type { MotherlodeMiningActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, itemNameFromID } from '../../../lib/util';
+import { formatDurationFromUser, itemNameFromID } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { minionName } from '../../../lib/util/minionUtils';

--- a/src/mahoji/lib/abstracted_commands/nexCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nexCommand.ts
@@ -6,7 +6,7 @@ import { trackLoot } from '../../../lib/lootTrack';
 import { setupParty } from '../../../lib/party';
 import { calculateNexDetails, checkNexUser } from '../../../lib/simulation/nex';
 import type { NexTaskOptions } from '../../../lib/types/minions';
-import { calcPerHour, formatDuration, formatDurationFromUser } from '../../../lib/util';
+import { calcPerHour, formatDurationFromUser } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { deferInteraction } from '../../../lib/util/interactionReply';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';

--- a/src/mahoji/lib/abstracted_commands/nightmareZoneCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/nightmareZoneCommand.ts
@@ -9,7 +9,7 @@ import { resolveAttackStyles } from '../../../lib/minions/functions';
 import { getMinigameEntity } from '../../../lib/settings/minigames';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { Skills } from '../../../lib/types';
-import { formatDuration, formatDurationFromUser, hasSkillReqs, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, hasSkillReqs, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';

--- a/src/mahoji/lib/abstracted_commands/pestControlCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/pestControlCommand.ts
@@ -7,7 +7,7 @@ import { WesternProv, userhasDiaryTier } from '../../../lib/diaries';
 import { getMinigameScore } from '../../../lib/settings/settings';
 import type { SkillsEnum } from '../../../lib/skilling/types';
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, hasSkillReqs, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, hasSkillReqs, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';

--- a/src/mahoji/lib/abstracted_commands/puroPuroCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/puroPuroCommand.ts
@@ -3,7 +3,7 @@ import { Time } from 'e';
 import type { Item } from 'oldschooljs';
 import type { Skills } from '../../../lib/types';
 import type { PuroPuroActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, hasSkillReqs, itemID, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, hasSkillReqs, itemID, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';

--- a/src/mahoji/lib/abstracted_commands/questCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/questCommand.ts
@@ -1,6 +1,5 @@
 import { Time, sumArr } from 'e';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
 import { MAX_GLOBAL_QP, MAX_QP, quests } from '../../../lib/minions/data/quests';
 import type { ActivityTaskOptionsWithNoChanges, SpecificQuestOptions } from '../../../lib/types/minions';
 import { formatDurationFromUser } from '../../../lib/util';

--- a/src/mahoji/lib/abstracted_commands/scatterCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/scatterCommand.ts
@@ -5,7 +5,7 @@ import { BitField } from '../../../lib/constants';
 import Prayer from '../../../lib/skilling/skills/prayer';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { ScatteringActivityTaskOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 
@@ -42,13 +42,14 @@ export async function scatterCommand(user: MUser, channelID: string, ashName: st
 
 	const duration = quantity * timeToScatterAnAsh;
 
-	if (duration > maxTripLength) {
-		return `${user.minionName} can't go on trips longer than ${formatDuration(
-			maxTripLength
-		)}, try a lower quantity. The highest amount of ${ash.name}s you can scatter is ${Math.floor(
-			maxTripLength / timeToScatterAnAsh
-		)}.`;
-	}
+        if (duration > maxTripLength) {
+                return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                        maxTripLength,
+                        user
+                )}, try a lower quantity. The highest amount of ${ash.name}s you can scatter is ${Math.floor(
+                        maxTripLength / timeToScatterAnAsh
+                )}.`;
+        }
 
 	await transactItems({ userID: user.id, itemsToRemove: cost });
 

--- a/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/shootingStarsCommand.ts
@@ -10,7 +10,7 @@ import { pickaxes } from '../../../lib/skilling/functions/miningBoosts';
 import type { Ore } from '../../../lib/skilling/types';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { ActivityTaskData, ShootingStarsOptions } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, itemNameFromID } from '../../../lib/util';
+import { formatDurationFromUser, itemNameFromID } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength, patronMaxTripBonus } from '../../../lib/util/calcMaxTripLength';
 import { minionName } from '../../../lib/util/minionUtils';

--- a/src/mahoji/lib/abstracted_commands/soulWarsCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/soulWarsCommand.ts
@@ -3,7 +3,7 @@ import { Time } from 'e';
 import { Bank } from 'oldschooljs';
 
 import type { MinigameActivityTaskOptionsWithNoChanges } from '../../../lib/types/minions';
-import { formatDuration, formatDurationFromUser, randomVariation, stringMatches } from '../../../lib/util';
+import { formatDurationFromUser, randomVariation, stringMatches } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import getOSItem from '../../../lib/util/getOSItem';

--- a/src/mahoji/lib/abstracted_commands/volcanicMineCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/volcanicMineCommand.ts
@@ -2,7 +2,6 @@ import type { ChatInputCommandInteraction } from 'discord.js';
 import { Time, objectEntries } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
 import { getMinigameScore } from '../../../lib/settings/minigames';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { ActivityTaskOptionsWithQuantity } from '../../../lib/types/minions';

--- a/src/mahoji/lib/abstracted_commands/warriorsGuildCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/warriorsGuildCommand.ts
@@ -1,7 +1,7 @@
 import { Time } from 'e';
 import { Bank } from 'oldschooljs';
 
-import { formatDuration } from '@oldschoolgg/toolkit/util';
+
 import { resolveItems } from 'oldschooljs/dist/util/util';
 import type { ActivityTaskOptionsWithQuantity, AnimatedArmourActivityTaskOptions } from '../../../lib/types/minions';
 import { formatDurationFromUser } from '../../../lib/util';
@@ -52,13 +52,14 @@ async function tokensCommand(user: MUser, channelID: string, quantity: number | 
 
 	const duration = armorSet.timeToFinish * quantity;
 
-	if (duration > maxTripLength) {
-		return `${user.minionName} can't go on trips longer than ${formatDuration(
-			maxTripLength
-		)}, try a lower quantity. The highest amount of animated ${armorSet.name} armour you can kill is ${Math.floor(
-			maxTripLength / armorSet.timeToFinish
-		)}.`;
-	}
+        if (duration > maxTripLength) {
+                return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                        maxTripLength,
+                        user
+                )}, try a lower quantity. The highest amount of animated ${armorSet.name} armour you can kill is ${Math.floor(
+                        maxTripLength / armorSet.timeToFinish
+                )}.`;
+        }
 
 	await addSubTaskToActivityTask<AnimatedArmourActivityTaskOptions>({
 		armourID: armorSet.name,
@@ -95,23 +96,25 @@ async function cyclopsCommand(user: MUser, channelID: string, quantity: number |
 
 	const duration = Time.Second * 30 * quantity;
 
-	if (duration > maxTripLength) {
-		return `${user.minionName} can't go on trips longer than ${formatDuration(
-			maxTripLength
-		)}, try a lower quantity. The highest amount of cyclopes that can be killed is ${Math.floor(
-			maxTripLength / (Time.Second * 30)
-		)}.`;
-	}
+        if (duration > maxTripLength) {
+                return `${user.minionName} can't go on trips longer than ${formatDurationFromUser(
+                        maxTripLength,
+                        user
+                )}, try a lower quantity. The highest amount of cyclopes that can be killed is ${Math.floor(
+                        maxTripLength / (Time.Second * 30)
+                )}.`;
+        }
 
 	const tokensToSpend = Math.floor((duration / Time.Minute) * 10 + 10);
 
-	if (!hasAttackCape && amountTokens < tokensToSpend) {
-		return `You don't have enough Warrior guild tokens to kill cyclopes for ${formatDuration(
-			duration
-		)}, try a lower quantity. You need at least ${Math.floor(
-			(duration / Time.Minute) * 10 + 10
-		)}x Warrior guild tokens to kill ${quantity}x cyclopes.`;
-	}
+                if (!hasAttackCape && amountTokens < tokensToSpend) {
+                        return `You don't have enough Warrior guild tokens to kill cyclopes for ${formatDurationFromUser(
+                                duration,
+                                user
+                        )}, try a lower quantity. You need at least ${Math.floor(
+                                (duration / Time.Minute) * 10 + 10
+                        )}x Warrior guild tokens to kill ${quantity}x cyclopes.`;
+                }
 
 	await addSubTaskToActivityTask<ActivityTaskOptionsWithQuantity>({
 		userID: user.id,


### PR DESCRIPTION
## Summary
- ensure duration displays respect user ShowMinionReturnTime bitfield
- remove unused `formatDuration` imports
- update numerous commands to call `formatDurationFromUser`

## Testing
- `pnpm lint` *(fails: tsx not found)*
- `pnpm dev` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487f823dd4832689f70480009c72ea