### PR TITLE
Add miscellania simulation support

### DIFF
--- a/tests/integration/commands/simulateMiscellania.test.ts
+++ b/tests/integration/commands/simulateMiscellania.test.ts
@@ -1,0 +1,15 @@
+import { describe, test, expect } from 'vitest';
+
+import { simulateCommand } from '../../../src/mahoji/commands/simulate';
+import { createTestUser, mockClient } from '../util';
+
+
+describe('Simulate Miscellania', async () => {
+  await mockClient();
+
+  test('returns image', async () => {
+    const user = await createTestUser();
+    const result: any = await user.runCommand(simulateCommand, { miscellania: { days: 3 } });
+    expect(result.files?.length).toBe(1);
+  });
+});

--- a/tests/integration/commands/testpotatoMiscellania.test.ts
+++ b/tests/integration/commands/testpotatoMiscellania.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from 'vitest';
+
+import { Time } from 'e';
+import { testPotatoCommand } from '../../../src/mahoji/commands/testpotato';
+import { createTestUser, mockClient } from '../util';
+
+describe('Testpotato Miscellania', async () => {
+  await mockClient();
+
+  test('updates miscellania data', async () => {
+    const user = await createTestUser();
+    await user.runCommand(
+      testPotatoCommand!,
+      { miscellania: { coffer: 5000, approval: 75, days_ago: 3 } },
+      true
+    );
+    const data: any = user.user.minion_miscellania;
+    expect(data.coffer).toBe(5000);
+    expect(Math.round(data.approval)).toBe(75);
+    const days = Math.round((Date.now() - data.lastCollect) / Time.Day);
+    expect(days).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- support simulating miscellania collection
- allow testpotato to grant miscellania loot
- allow editing miscellania state via testpotato
- add tests for new simulate and testpotato functionality

## Testing
- `pnpm test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f311a2a483269e7c902cb4477890