### PR TITLE
Add ability to view all 'other' minion stats

### DIFF
--- a/src/mahoji/commands/minion.ts
+++ b/src/mahoji/commands/minion.ts
@@ -152,11 +152,19 @@ export const minionCommand: OSBMahojiCommand = {
 				}
 			]
 		},
-		{
-			type: ApplicationCommandOptionType.Subcommand,
-			name: 'stats',
-			description: 'Check the stats of your minion.'
-		},
+               {
+                       type: ApplicationCommandOptionType.Subcommand,
+                       name: 'stats',
+                       description: 'Check the stats of your minion.',
+                       options: [
+                               {
+                                       type: ApplicationCommandOptionType.Boolean,
+                                       name: 'other',
+                                       description: 'Show only the "Other" stats?',
+                                       required: false
+                               }
+                       ]
+               },
 		{
 			type: ApplicationCommandOptionType.Subcommand,
 			name: 'achievementdiary',
@@ -426,7 +434,7 @@ export const minionCommand: OSBMahojiCommand = {
 		interaction,
 		channelID
 	}: CommandRunOptions<{
-		stats?: { stat?: string };
+               stats?: { stat?: string; other?: boolean };
 		achievementdiary?: { diary?: string; claim?: boolean };
 		bankbg?: { name?: string };
 		cracker?: { user: MahojiUserOption };
@@ -454,9 +462,15 @@ export const minionCommand: OSBMahojiCommand = {
 		if (options.info) return (await getUserInfo(user)).everythingString;
 		if (options.status) return minionStatusCommand(user);
 
-		if (options.stats) {
-			return { embeds: [await minionStatsEmbed(user)] };
-		}
+               if (options.stats) {
+                       return {
+                               embeds: [
+                                       await minionStatsEmbed(user, {
+                                               otherOnly: options.stats.other ?? false
+                                       })
+                               ]
+                       };
+               }
 
 		if (options.achievementdiary) {
 			if (options.achievementdiary.claim) {

--- a/tests/integration/misc.test.ts
+++ b/tests/integration/misc.test.ts
@@ -10,9 +10,9 @@ import { minionStatsEmbed } from '../../src/lib/util/minionStatsEmbed';
 import { createTestUser, mockClient } from './util';
 
 describe('Integration Misc', () => {
-	test('minionStatsEmbed', async () => {
-		await minionStatsEmbed(await mUserFetch('1111'));
-	});
+       test('minionStatsEmbed', async () => {
+               await minionStatsEmbed(await mUserFetch('1111'), { otherOnly: true });
+       });
 	test('Analytics', async () => {
 		await mockClient();
 		await analyticsTick();


### PR DESCRIPTION
## Summary
- add `otherOnly` option to minionStatsEmbed
- expose new `other` boolean on `/minion stats`
- adjust integration test

Closes 1925 