### PR TITLE
Add generic buy trip capability

### DIFF
--- a/docs/src/content/docs/osb/Miscelleanous/buyable-items-and-shop-pricing-mechanics.mdx
+++ b/docs/src/content/docs/osb/Miscelleanous/buyable-items-and-shop-pricing-mechanics.mdx
@@ -3,9 +3,11 @@ title: "Buyable Items and Shop Pricing Mechanics"
 ---
 
 ## Overview
-Buying trips allow your minion to purchase large quantities of certain items over time.
-Most buyables are purchased instantly for a flat GP price. Others simulate shop
-mechanics where prices rise as stock is bought and the minion must world hop.
+Most items bought with `/buy` are delivered instantly at their listed GP price.
+For some resources your minion must travel to in‑game shops. When this happens
+you'll see a confirmation showing the total cost and trip duration. Accepting
+the prompt sends your minion on a timed buying trip that mimics hopping between
+OSRS worlds.
 
 ## Instant Buyables
 Items without `shopQuantity` or `changePer` simply cost their listed `gpCost`.
@@ -20,6 +22,11 @@ Some items come from in game shops and follow Old School RuneScape pricing rules
 - **shopQuantity** – items available before world hopping.
 
 Price increases linearly within a world and resets after each hop.
+
+When a shop buyable is requested the bot shows a summary like
+"Buying **5000 Gold ore** will cost **1,125,000gp** and take about
+**27 minutes**. Continue?" Accepting sends your minion off to hop worlds and buy
+the items.
 
 Example: Arrow shafts start at 1 GP each and increase by 1% per shaft. After
 buying 1000 the average price is around 5.5 GP before hopping.

--- a/docs/src/content/docs/osb/Miscelleanous/buyable-items-and-shop-pricing-mechanics.mdx
+++ b/docs/src/content/docs/osb/Miscelleanous/buyable-items-and-shop-pricing-mechanics.mdx
@@ -44,8 +44,11 @@ Every `shopQuantity` items the minion hops to a new world and pricing starts ove
 - `quantityPerHour: number` – limits trip length
 
 ### Current Shop-Based Buyables
-Arrow shafts, Blood runes, Law runes, Soul runes, Astral runes, Death runes,
-Nature runes and Chaos runes.
+A few notable examples are:
+
+- **Arrow shafts** – bought in bulk with rising prices.
+- **Blood runes** (and other elemental runes).
+- **Gold ore** and other ores sold at shops.
 
 Most items remain simple flat-cost purchases but these shop buyables use the
 `calculateShopBuyCost` function to determine total and average price while

--- a/docs/src/content/docs/osb/Miscelleanous/buyable-items-and-shop-pricing-mechanics.mdx
+++ b/docs/src/content/docs/osb/Miscelleanous/buyable-items-and-shop-pricing-mechanics.mdx
@@ -1,0 +1,45 @@
+---
+title: "Buyable Items and Shop Pricing Mechanics"
+---
+
+## Overview
+Buying trips allow your minion to purchase large quantities of certain items over time.
+Most buyables are purchased instantly for a flat GP price. Others simulate shop
+mechanics where prices rise as stock is bought and the minion must world hop.
+
+## Instant Buyables
+Items without `shopQuantity` or `changePer` simply cost their listed `gpCost`.
+The GP is removed from your bank and the items are delivered immediately, like a
+virtual Grand Exchange.
+
+## Shop Buyables
+Some items come from in game shops and follow Old School RuneScape pricing rules:
+
+- **gpCost** – base price (100%).
+- **changePer** – price increase per item bought (e.g. `1` for +1%).
+- **shopQuantity** – items available before world hopping.
+
+Price increases linearly within a world and resets after each hop.
+
+Example: Arrow shafts start at 1 GP each and increase by 1% per shaft. After
+buying 1000 the average price is around 5.5 GP before hopping.
+
+```ts
+price = Math.floor(basePrice * (1 + changePer / 100 * itemsBoughtInWorld))
+```
+
+Every `shopQuantity` items the minion hops to a new world and pricing starts over.
+
+### Fields Used in Code
+- `gpCost: number`
+- `shopQuantity?: number`
+- `changePer?: number`
+- `quantityPerHour: number` – limits trip length
+
+### Current Shop-Based Buyables
+Arrow shafts, Blood runes, Law runes, Soul runes, Astral runes, Death runes,
+Nature runes and Chaos runes.
+
+Most items remain simple flat-cost purchases but these shop buyables use the
+`calculateShopBuyCost` function to determine total and average price while
+world hopping.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -934,6 +934,7 @@ enum activity_type_enum {
   MyNotes
   Colosseum
   CreateForestersRations
+  Buy
 }
 
 enum xp_gains_skill_enum {

--- a/src/lib/Task.ts
+++ b/src/lib/Task.ts
@@ -87,6 +87,7 @@ import { specificQuestTask } from '../tasks/minions/specificQuestActivity';
 import { strongholdTask } from '../tasks/minions/strongholdOfSecurityActivity';
 import { tiaraRunecraftTask } from '../tasks/minions/tiaraRunecraftActivity';
 import { tokkulShopTask } from '../tasks/minions/tokkulShopActivity';
+import { buyTask } from '../tasks/minions/buyActivity';
 import { vmTask } from '../tasks/minions/volcanicMineActivity';
 import { wealthChargeTask } from '../tasks/minions/wealthChargingActivity';
 import { woodcuttingTask } from '../tasks/minions/woodcuttingActivity';
@@ -193,7 +194,8 @@ const tasks: MinionTask[] = [
 	camdozaalFishingTask,
 	myNotesTask,
 	colosseumTask,
-	CreateForestersRationsTask
+	CreateForestersRationsTask,
+	buyTask
 ];
 
 export async function processPendingActivities() {

--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -24,6 +24,7 @@ import { shootingStarsBuyables } from './shootingStarsBuyables';
 import { skillCapeBuyables } from './skillCapeBuyables';
 import { slayerBuyables } from './slayerBuyables';
 import { troubleBrewingBuyables } from './troubleBrewingShop';
+import { tripBuyables } from './tripBuyables';
 
 export interface Buyable {
 	name: string;
@@ -38,8 +39,9 @@ export interface Buyable {
 	minigameScoreReq?: [MinigameName, number];
 	ironmanPrice?: number;
 	collectionLogReqs?: number[];
-	customReq?: (user: MUser, userStats: MUserStats) => Promise<[true] | [false, string]>;
-	maxQuantity?: number;
+        customReq?: (user: MUser, userStats: MUserStats) => Promise<[true] | [false, string]>;
+        maxQuantity?: number;
+       quantityPerHour?: number;
 }
 
 const randomEventBuyables: Buyable[] = [
@@ -1149,9 +1151,10 @@ const Buyables: Buyable[] = [
 	...shootingStarsBuyables,
 	...guardiansOfTheRiftBuyables,
 	...toaCapes,
-	...mairinsMarketBuyables,
-	...forestryBuyables,
-	...colossalWyrmAgilityBuyables
+        ...mairinsMarketBuyables,
+        ...forestryBuyables,
+        ...colossalWyrmAgilityBuyables,
+        ...tripBuyables
 ];
 
 for (const [chompyHat, qty] of chompyHats) {
@@ -1164,11 +1167,12 @@ for (const [chompyHat, qty] of chompyHats) {
 }
 
 for (const cape of allTeamCapes) {
-	Buyables.push({
-		name: cape.name,
-		outputItems: new Bank().add(cape.id),
-		gpCost: 15_000
-	});
+        Buyables.push({
+                name: cape.name,
+                outputItems: new Bank().add(cape.id),
+                gpCost: 15_000
+        });
 }
+
 
 export default Buyables;

--- a/src/lib/data/buyables/buyables.ts
+++ b/src/lib/data/buyables/buyables.ts
@@ -42,6 +42,8 @@ export interface Buyable {
         customReq?: (user: MUser, userStats: MUserStats) => Promise<[true] | [false, string]>;
         maxQuantity?: number;
        quantityPerHour?: number;
+       shopQuantity?: number;
+       changePer?: number;
 }
 
 const randomEventBuyables: Buyable[] = [

--- a/src/lib/data/buyables/tripBuyables.ts
+++ b/src/lib/data/buyables/tripBuyables.ts
@@ -1,0 +1,50 @@
+import { Bank } from 'oldschooljs';
+
+import type { Buyable } from './buyables';
+
+export const tripBuyables: Buyable[] = [
+  {
+    name: 'Copper ore',
+    outputItems: new Bank().add('Copper ore'),
+    gpCost: 4,
+    quantityPerHour: 11000
+  },
+  {
+    name: 'Tin ore',
+    outputItems: new Bank().add('Tin ore'),
+    gpCost: 4,
+    quantityPerHour: 11000
+  },
+  {
+    name: 'Iron ore',
+    outputItems: new Bank().add('Iron ore'),
+    gpCost: 25,
+    quantityPerHour: 11000
+  },
+  {
+    name: 'Mithril ore',
+    outputItems: new Bank().add('Mithril ore'),
+    gpCost: 243,
+    quantityPerHour: 11000
+  },
+  {
+    name: 'Silver ore',
+    outputItems: new Bank().add('Silver ore'),
+    gpCost: 112,
+    quantityPerHour: 11000
+  },
+  {
+    name: 'Gold ore',
+    outputItems: new Bank().add('Gold ore'),
+    gpCost: 225,
+    quantityPerHour: 11000
+  },
+  {
+    name: 'Coal',
+    outputItems: new Bank().add('Coal'),
+    gpCost: 67,
+    quantityPerHour: 11000
+  }
+];
+
+export default tripBuyables;

--- a/src/lib/data/buyables/tripBuyables.ts
+++ b/src/lib/data/buyables/tripBuyables.ts
@@ -4,6 +4,14 @@ import type { Buyable } from './buyables';
 
 export const tripBuyables: Buyable[] = [
   {
+    name: 'Arrow shaft',
+    outputItems: new Bank().add('Arrow shaft'),
+    gpCost: 1,
+    quantityPerHour: 400_000,
+    shopQuantity: 1000,
+    changePer: 1
+  },
+  {
     name: 'Copper ore',
     outputItems: new Bank().add('Copper ore'),
     gpCost: 4,

--- a/src/lib/data/buyables/tripBuyables.ts
+++ b/src/lib/data/buyables/tripBuyables.ts
@@ -3,112 +3,112 @@ import { Bank } from 'oldschooljs';
 import type { Buyable } from './buyables';
 
 export const tripBuyables: Buyable[] = [
-  {
-    name: 'Arrow shaft',
-    outputItems: new Bank().add('Arrow shaft'),
-    gpCost: 1,
-    quantityPerHour: 400_000,
-    shopQuantity: 1000,
-    changePer: 1
-  },
-  {
-    name: 'Copper ore',
-    outputItems: new Bank().add('Copper ore'),
-    gpCost: 4,
-    quantityPerHour: 11000
-  },
-  {
-    name: 'Tin ore',
-    outputItems: new Bank().add('Tin ore'),
-    gpCost: 4,
-    quantityPerHour: 11000
-  },
-  {
-    name: 'Iron ore',
-    outputItems: new Bank().add('Iron ore'),
-    gpCost: 25,
-    quantityPerHour: 11000
-  },
-  {
-    name: 'Mithril ore',
-    outputItems: new Bank().add('Mithril ore'),
-    gpCost: 243,
-    quantityPerHour: 11000
-  },
-  {
-    name: 'Silver ore',
-    outputItems: new Bank().add('Silver ore'),
-    gpCost: 112,
-    quantityPerHour: 11000
-  },
-  {
-    name: 'Gold ore',
-    outputItems: new Bank().add('Gold ore'),
-    gpCost: 225,
-    quantityPerHour: 11000
-  },
-  {
-    name: 'Coal',
-    outputItems: new Bank().add('Coal'),
-    gpCost: 67,
-    quantityPerHour: 11000
-  },
-  {
-    name: 'Blood rune',
-    outputItems: new Bank().add('Blood rune'),
-    gpCost: 400,
-    quantityPerHour: 100_000,
-    shopQuantity: 1000,
-    changePer: 0.1
-  },
-  {
-    name: 'Law rune',
-    outputItems: new Bank().add('Law rune'),
-    gpCost: 240,
-    quantityPerHour: 100_000,
-    shopQuantity: 1000,
-    changePer: 0.1
-  },
-  {
-    name: 'Soul rune',
-    outputItems: new Bank().add('Soul rune'),
-    gpCost: 300,
-    quantityPerHour: 100_000,
-    shopQuantity: 1000,
-    changePer: 0.1
-  },
-  {
-    name: 'Astral rune',
-    outputItems: new Bank().add('Astral rune'),
-    gpCost: 50,
-    quantityPerHour: 100_000,
-    shopQuantity: 1000,
-    changePer: 0.1
-  },
-  {
-    name: 'Death rune',
-    outputItems: new Bank().add('Death rune'),
-    gpCost: 180,
-    quantityPerHour: 100_000,
-    shopQuantity: 1000,
-    changePer: 0.1
-  },
-  {
-    name: 'Nature rune',
-    outputItems: new Bank().add('Nature rune'),
-    gpCost: 180,
-    quantityPerHour: 100_000,
-    shopQuantity: 1000,
-    changePer: 0.1
-  },
-  {
-    name: 'Chaos rune',
-    outputItems: new Bank().add('Chaos rune'),
-    gpCost: 90,
-    quantityPerHour: 100_000,
-    shopQuantity: 1000,
-    changePer: 0.1
-  }
+	{
+		name: 'Arrow shaft',
+		outputItems: new Bank().add('Arrow shaft'),
+		gpCost: 1,
+		quantityPerHour: 400_000,
+		shopQuantity: 1000,
+		changePer: 1
+	},
+	{
+		name: 'Copper ore',
+		outputItems: new Bank().add('Copper ore'),
+		gpCost: 4,
+		quantityPerHour: 11000
+	},
+	{
+		name: 'Tin ore',
+		outputItems: new Bank().add('Tin ore'),
+		gpCost: 4,
+		quantityPerHour: 11000
+	},
+	{
+		name: 'Iron ore',
+		outputItems: new Bank().add('Iron ore'),
+		gpCost: 25,
+		quantityPerHour: 11000
+	},
+	{
+		name: 'Mithril ore',
+		outputItems: new Bank().add('Mithril ore'),
+		gpCost: 243,
+		quantityPerHour: 11000
+	},
+	{
+		name: 'Silver ore',
+		outputItems: new Bank().add('Silver ore'),
+		gpCost: 112,
+		quantityPerHour: 11000
+	},
+	{
+		name: 'Gold ore',
+		outputItems: new Bank().add('Gold ore'),
+		gpCost: 225,
+		quantityPerHour: 11000
+	},
+	{
+		name: 'Coal',
+		outputItems: new Bank().add('Coal'),
+		gpCost: 67,
+		quantityPerHour: 11000
+	},
+	{
+		name: 'Blood rune',
+		outputItems: new Bank().add('Blood rune'),
+		gpCost: 400,
+		quantityPerHour: 100_000,
+		shopQuantity: 1000,
+		changePer: 0.1
+	},
+	{
+		name: 'Law rune',
+		outputItems: new Bank().add('Law rune'),
+		gpCost: 240,
+		quantityPerHour: 100_000,
+		shopQuantity: 1000,
+		changePer: 0.1
+	},
+	{
+		name: 'Soul rune',
+		outputItems: new Bank().add('Soul rune'),
+		gpCost: 300,
+		quantityPerHour: 100_000,
+		shopQuantity: 1000,
+		changePer: 0.1
+	},
+	{
+		name: 'Astral rune',
+		outputItems: new Bank().add('Astral rune'),
+		gpCost: 50,
+		quantityPerHour: 100_000,
+		shopQuantity: 1000,
+		changePer: 0.1
+	},
+	{
+		name: 'Death rune',
+		outputItems: new Bank().add('Death rune'),
+		gpCost: 180,
+		quantityPerHour: 100_000,
+		shopQuantity: 1000,
+		changePer: 0.1
+	},
+	{
+		name: 'Nature rune',
+		outputItems: new Bank().add('Nature rune'),
+		gpCost: 180,
+		quantityPerHour: 100_000,
+		shopQuantity: 1000,
+		changePer: 0.1
+	},
+	{
+		name: 'Chaos rune',
+		outputItems: new Bank().add('Chaos rune'),
+		gpCost: 90,
+		quantityPerHour: 100_000,
+		shopQuantity: 1000,
+		changePer: 0.1
+	}
 ];
 
 export default tripBuyables;

--- a/src/lib/data/buyables/tripBuyables.ts
+++ b/src/lib/data/buyables/tripBuyables.ts
@@ -52,6 +52,62 @@ export const tripBuyables: Buyable[] = [
     outputItems: new Bank().add('Coal'),
     gpCost: 67,
     quantityPerHour: 11000
+  },
+  {
+    name: 'Blood rune',
+    outputItems: new Bank().add('Blood rune'),
+    gpCost: 400,
+    quantityPerHour: 100_000,
+    shopQuantity: 1000,
+    changePer: 0.1
+  },
+  {
+    name: 'Law rune',
+    outputItems: new Bank().add('Law rune'),
+    gpCost: 240,
+    quantityPerHour: 100_000,
+    shopQuantity: 1000,
+    changePer: 0.1
+  },
+  {
+    name: 'Soul rune',
+    outputItems: new Bank().add('Soul rune'),
+    gpCost: 300,
+    quantityPerHour: 100_000,
+    shopQuantity: 1000,
+    changePer: 0.1
+  },
+  {
+    name: 'Astral rune',
+    outputItems: new Bank().add('Astral rune'),
+    gpCost: 50,
+    quantityPerHour: 100_000,
+    shopQuantity: 1000,
+    changePer: 0.1
+  },
+  {
+    name: 'Death rune',
+    outputItems: new Bank().add('Death rune'),
+    gpCost: 180,
+    quantityPerHour: 100_000,
+    shopQuantity: 1000,
+    changePer: 0.1
+  },
+  {
+    name: 'Nature rune',
+    outputItems: new Bank().add('Nature rune'),
+    gpCost: 180,
+    quantityPerHour: 100_000,
+    shopQuantity: 1000,
+    changePer: 0.1
+  },
+  {
+    name: 'Chaos rune',
+    outputItems: new Bank().add('Chaos rune'),
+    gpCost: 90,
+    quantityPerHour: 100_000,
+    shopQuantity: 1000,
+    changePer: 0.1
   }
 ];
 

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -534,7 +534,6 @@ export interface BuyActivityTaskOptions extends ActivityTaskOptions {
        itemID: number;
        quantity: number;
        totalCost: number;
-       average: number;
 }
 
 export interface UnderwaterAgilityThievingTaskOptions extends ActivityTaskOptions {

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -530,9 +530,11 @@ export interface TokkulShopOptions extends ActivityTaskOptions {
 }
 
 export interface BuyActivityTaskOptions extends ActivityTaskOptions {
-       type: 'Buy';
-       itemID: number;
-       quantity: number;
+        type: 'Buy';
+        itemID: number;
+        quantity: number;
+       totalCost: number;
+       average: number;
 }
 
 export interface UnderwaterAgilityThievingTaskOptions extends ActivityTaskOptions {

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -529,6 +529,12 @@ export interface TokkulShopOptions extends ActivityTaskOptions {
 	quantity: number;
 }
 
+export interface BuyActivityTaskOptions extends ActivityTaskOptions {
+       type: 'Buy';
+       itemID: number;
+       quantity: number;
+}
+
 export interface UnderwaterAgilityThievingTaskOptions extends ActivityTaskOptions {
 	type: 'UnderwaterAgilityThieving';
 	trainingSkill: UnderwaterAgilityThievingTrainingSkill;
@@ -634,6 +640,7 @@ export type ActivityTaskData =
 	| SpecificQuestOptions
 	| ActivityTaskOptionsWithNoChanges
 	| TokkulShopOptions
+	| BuyActivityTaskOptions
 	| BirdhouseActivityTaskOptions
 	| FightCavesActivityTaskOptions
 	| ActivityTaskOptionsWithQuantity

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -530,11 +530,9 @@ export interface TokkulShopOptions extends ActivityTaskOptions {
 }
 
 export interface BuyActivityTaskOptions extends ActivityTaskOptions {
-        type: 'Buy';
-        itemID: number;
-        quantity: number;
-       totalCost: number;
-       average: number;
+       type: 'Buy';
+       itemID: number;
+       quantity: number;
 }
 
 export interface UnderwaterAgilityThievingTaskOptions extends ActivityTaskOptions {

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -533,6 +533,8 @@ export interface BuyActivityTaskOptions extends ActivityTaskOptions {
        type: 'Buy';
        itemID: number;
        quantity: number;
+       totalCost: number;
+       average: number;
 }
 
 export interface UnderwaterAgilityThievingTaskOptions extends ActivityTaskOptions {

--- a/src/lib/util/calculateShopBuyCost.ts
+++ b/src/lib/util/calculateShopBuyCost.ts
@@ -4,6 +4,9 @@ export function calculateShopBuyCost(
 	shopQuantity?: number,
 	changePer?: number
 ): { total: number; average: number } {
+	if (quantity === 0) {
+		return { total: 0, average: 0 };
+	}
 	if (!shopQuantity || !changePer) {
 		const total = gpCost * quantity;
 		return { total, average: total / quantity };

--- a/src/lib/util/calculateShopBuyCost.ts
+++ b/src/lib/util/calculateShopBuyCost.ts
@@ -1,22 +1,22 @@
 export function calculateShopBuyCost(
-  gpCost: number,
-  quantity: number,
-  shopQuantity?: number,
-  changePer?: number
+	gpCost: number,
+	quantity: number,
+	shopQuantity?: number,
+	changePer?: number
 ): { total: number; average: number } {
-  if (!shopQuantity || !changePer) {
-    const total = gpCost * quantity;
-    return { total, average: total / quantity };
-  }
+	if (!shopQuantity || !changePer) {
+		const total = gpCost * quantity;
+		return { total, average: total / quantity };
+	}
 
-  let total = 0;
-  for (let i = 0; i < quantity; i++) {
-    const itemsBoughtThisWorld = i % shopQuantity;
-    const price = Math.floor(gpCost * (1 + (changePer / 100) * itemsBoughtThisWorld));
-    total += price;
-  }
+	let total = 0;
+	for (let i = 0; i < quantity; i++) {
+		const itemsBoughtThisWorld = i % shopQuantity;
+		const price = Math.floor(gpCost * (1 + (changePer / 100) * itemsBoughtThisWorld));
+		total += price;
+	}
 
-  return { total, average: total / quantity };
+	return { total, average: total / quantity };
 }
 
 export default calculateShopBuyCost;

--- a/src/lib/util/calculateShopBuyCost.ts
+++ b/src/lib/util/calculateShopBuyCost.ts
@@ -1,0 +1,23 @@
+export function calculateShopBuyCost(
+  gpCost: number,
+  quantity: number,
+  shopQuantity?: number,
+  changePer?: number
+): { total: number; average: number } {
+  if (!shopQuantity || !changePer) {
+    const total = gpCost * quantity;
+    return { total, average: total / quantity };
+  }
+  let total = 0;
+  let price = gpCost;
+  const multiplier = 1 + changePer / 100;
+  for (let i = 0; i < quantity; i++) {
+    total += Math.floor(price);
+    price *= multiplier;
+    if ((i + 1) % shopQuantity === 0) {
+      price = gpCost;
+    }
+  }
+  return { total, average: total / quantity };
+}
+export default calculateShopBuyCost;

--- a/src/lib/util/calculateShopBuyCost.ts
+++ b/src/lib/util/calculateShopBuyCost.ts
@@ -8,16 +8,15 @@ export function calculateShopBuyCost(
     const total = gpCost * quantity;
     return { total, average: total / quantity };
   }
+
   let total = 0;
-  let price = gpCost;
-  const multiplier = 1 + changePer / 100;
   for (let i = 0; i < quantity; i++) {
-    total += Math.floor(price);
-    price *= multiplier;
-    if ((i + 1) % shopQuantity === 0) {
-      price = gpCost;
-    }
+    const itemsBoughtThisWorld = i % shopQuantity;
+    const price = Math.floor(gpCost * (1 + (changePer / 100) * itemsBoughtThisWorld));
+    total += price;
   }
+
   return { total, average: total / quantity };
 }
+
 export default calculateShopBuyCost;

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -66,11 +66,12 @@ import type {
 	OfferingActivityTaskOptions,
 	PickpocketActivityTaskOptions,
 	PlunderActivityTaskOptions,
-	RaidsOptions,
-	RunecraftActivityTaskOptions,
-	SawmillActivityTaskOptions,
-	ScatteringActivityTaskOptions,
-	SepulchreActivityTaskOptions,
+       RaidsOptions,
+       RunecraftActivityTaskOptions,
+       SawmillActivityTaskOptions,
+       ScatteringActivityTaskOptions,
+       BuyActivityTaskOptions,
+       SepulchreActivityTaskOptions,
 	ShadesOfMortonOptions,
 	SmeltingActivityTaskOptions,
 	SmithingActivityTaskOptions,
@@ -625,6 +626,10 @@ export function minionStatus(user: MUser) {
 				durationRemaining
 			)}.`;
 		}
+               case 'Buy': {
+                       const data = currentTask as BuyActivityTaskOptions;
+                       return `${name} is currently buying ${data.quantity}x ${itemNameFromID(data.itemID)}. The trip should take ${formatDuration(durationRemaining)}.`;
+               }
 		case 'Nex': {
 			const data = currentTask as NexTaskOptions;
 			const durationRemaining = data.finishDate - data.duration + data.fakeDuration - Date.now();

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -62,6 +62,7 @@ import type {
 	TempleTrekkingActivityTaskOptions,
 	TheatreOfBloodTaskOptions,
 	TiaraRunecraftActivityTaskOptions,
+	BuyActivityTaskOptions,
 	WoodcuttingActivityTaskOptions,
 	ZalcanoActivityTaskOptions
 } from '../types/minions';
@@ -130,6 +131,10 @@ const tripHandlers = {
 	[activity_type_enum.TokkulShop]: {
 		commandName: 'm',
 		args: () => ({})
+	},
+	[activity_type_enum.Buy]: {
+		commandName: 'buy',
+		args: (data: BuyActivityTaskOptions) => ({ name: itemNameFromID(data.itemID), quantity: data.quantity })
 	},
 	[activity_type_enum.ShootingStars]: {
 		commandName: 'm',

--- a/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
@@ -1,0 +1,67 @@
+import { Time } from 'e';
+import { Bank } from 'oldschooljs';
+import type { ChatInputCommandInteraction } from 'discord.js';
+
+import type { Buyable } from '../../../lib/data/buyables/buyables';
+import type { BuyActivityTaskOptions } from '../../../lib/types/minions';
+import { formatDuration, itemNameFromID } from '../../../lib/util';
+import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
+import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
+import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
+import { updateBankSetting } from '../../../lib/util/updateBankSetting';
+import { transactItems } from '../../../lib/util/TransactItems';
+import getOSItem from '../../../lib/util/getOSItem';
+
+export async function buyingTripCommand(
+  user: MUser,
+  channelID: string,
+  buyable: Buyable,
+  quantity: number | null,
+  interaction: ChatInputCommandInteraction
+) {
+  const quantityPerHour = buyable.quantityPerHour!;
+  const timePerItem = Time.Hour / quantityPerHour;
+  const osItem = getOSItem(buyable.name);
+  const gpCost = buyable.gpCost ?? 0;
+
+  const maxTripLength = calcMaxTripLength(user, 'Buy');
+  if (!quantity) {
+    quantity = Math.floor(maxTripLength / timePerItem);
+  }
+  const duration = quantity * timePerItem;
+  if (duration > maxTripLength) {
+    return `${user.minionName} can't go on a trip longer than ${formatDuration(
+      maxTripLength
+    )}, try a lower quantity. The highest amount you can buy is ${Math.floor(
+      maxTripLength / timePerItem
+    )}.`;
+  }
+
+  const cost = new Bank().add('Coins', gpCost * quantity);
+  if (!user.owns(cost)) {
+    return `You need ${cost} to buy ${quantity}x ${osItem.name}.`;
+  }
+
+  await handleMahojiConfirmation(
+    interaction,
+    `Buying ${quantity}x ${osItem.name} will cost ${cost
+      .amount('Coins')
+      .toLocaleString()} GP and take ${formatDuration(duration)}. Please confirm.`
+  );
+
+  await transactItems({ userID: user.id, itemsToRemove: cost });
+  await updateBankSetting('buy_cost_bank', cost);
+
+  await addSubTaskToActivityTask<BuyActivityTaskOptions>({
+    type: 'Buy',
+    itemID: osItem.id,
+    quantity,
+    userID: user.id,
+    channelID: channelID.toString(),
+    duration
+  });
+
+  return `${user.minionName} is now buying ${quantity}x ${itemNameFromID(
+    osItem.id
+  )} and will return in ${formatDuration(duration)}.`;
+}

--- a/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
@@ -14,63 +14,63 @@ import getOSItem from '../../../lib/util/getOSItem';
 import calculateShopBuyCost from '../../../lib/util/calculateShopBuyCost';
 
 export async function buyingTripCommand(
-  user: MUser,
-  channelID: string,
-  buyable: Buyable,
-  quantity: number | null,
-  interaction: ChatInputCommandInteraction
+	user: MUser,
+	channelID: string,
+	buyable: Buyable,
+	quantity: number | null,
+	interaction: ChatInputCommandInteraction
 ) {
-  const quantityPerHour = buyable.quantityPerHour!;
-  const timePerItem = Time.Hour / quantityPerHour;
-  const osItem = getOSItem(buyable.name);
-  const gpCost = buyable.gpCost ?? 0;
+	const quantityPerHour = buyable.quantityPerHour!;
+	const timePerItem = Time.Hour / quantityPerHour;
+	const osItem = getOSItem(buyable.name);
+	const gpCost = buyable.gpCost ?? 0;
 
-  const maxTripLength = calcMaxTripLength(user, 'Buy');
-  if (!quantity) {
-    quantity = Math.floor(maxTripLength / timePerItem);
-  }
-  const duration = quantity * timePerItem;
-  if (duration > maxTripLength) {
-    return `${user.minionName} can't go on a trip longer than ${formatDuration(
-      maxTripLength
-    )}, try a lower quantity. The highest amount you can buy is ${Math.floor(
-      maxTripLength / timePerItem
-    )}.`;
-  }
+	const maxTripLength = calcMaxTripLength(user, 'Buy');
+	if (!quantity) {
+		quantity = Math.floor(maxTripLength / timePerItem);
+	}
+	const duration = quantity * timePerItem;
+	if (duration > maxTripLength) {
+		return `${user.minionName} can't go on a trip longer than ${formatDuration(
+			maxTripLength
+		)}, try a lower quantity. The highest amount you can buy is ${Math.floor(
+			maxTripLength / timePerItem
+		)}.`;
+	}
 
-  const { total: totalCost, average } = calculateShopBuyCost(
-    gpCost,
-    quantity,
-    buyable.shopQuantity,
-    buyable.changePer
-  );
-  const cost = new Bank().add('Coins', totalCost);
-  if (!user.owns(cost)) {
-    return `You need ${cost} to buy ${quantity}x ${osItem.name}.`;
-  }
+	const { total: totalCost, average } = calculateShopBuyCost(
+		gpCost,
+		quantity,
+		buyable.shopQuantity,
+		buyable.changePer
+	);
+	const cost = new Bank().add('Coins', totalCost);
+	if (!user.owns(cost)) {
+		return `You need ${cost} to buy ${quantity}x ${osItem.name}.`;
+	}
 
-  await handleMahojiConfirmation(
-    interaction,
-    `Buying ${quantity}x ${osItem.name} will cost ${totalCost.toLocaleString()} GP (avg ${Math.floor(
-      average
-    ).toLocaleString()} ea) and take ${formatDuration(duration)}. Please confirm.`
-  );
+	await handleMahojiConfirmation(
+		interaction,
+		`Buying ${quantity}x ${osItem.name} will cost ${totalCost.toLocaleString()} GP (avg ${Math.floor(
+			average
+		).toLocaleString()} ea) and take ${formatDuration(duration)}. Please confirm.`
+	);
 
-  await transactItems({ userID: user.id, itemsToRemove: cost });
-  await updateBankSetting('buy_cost_bank', cost);
+	await transactItems({ userID: user.id, itemsToRemove: cost });
+	await updateBankSetting('buy_cost_bank', cost);
 
-  await addSubTaskToActivityTask<BuyActivityTaskOptions>({
-    type: 'Buy',
-    itemID: osItem.id,
-    quantity,
-    totalCost,
-    average,
-    userID: user.id,
-    channelID: channelID.toString(),
-    duration
-  });
+	await addSubTaskToActivityTask<BuyActivityTaskOptions>({
+		type: 'Buy',
+		itemID: osItem.id,
+		quantity,
+		totalCost,
+		average,
+		userID: user.id,
+		channelID: channelID.toString(),
+		duration
+	});
 
-  return `${user.minionName} is now buying ${quantity}x ${itemNameFromID(
-    osItem.id
-  )} and will return in ${formatDuration(duration)}.`;
+	return `${user.minionName} is now buying ${quantity}x ${itemNameFromID(
+		osItem.id
+	)} and will return in ${formatDuration(duration)}.`;
 }

--- a/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
@@ -63,6 +63,8 @@ export async function buyingTripCommand(
     type: 'Buy',
     itemID: osItem.id,
     quantity,
+    totalCost,
+    average,
     userID: user.id,
     channelID: channelID.toString(),
     duration

--- a/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
@@ -35,12 +35,12 @@ export async function buyingTripCommand(
 		)}, try a lower quantity. The highest amount you can buy is ${Math.floor(maxTripLength / timePerItem)}.`;
 	}
 
-	const { total: totalCost, average } = calculateShopBuyCost(
-		gpCost,
-		quantity,
-		buyable.shopQuantity,
-		buyable.changePer
-	);
+       const { total: totalCost, average } = calculateShopBuyCost(
+               gpCost,
+               quantity,
+               buyable.shopQuantity,
+               buyable.changePer
+       );
 	const cost = new Bank().add('Coins', totalCost);
 	if (!user.owns(cost)) {
 		return `You need ${cost} to buy ${quantity}x ${osItem.name}.`;
@@ -63,8 +63,7 @@ export async function buyingTripCommand(
                userID: user.id,
                channelID: channelID.toString(),
                duration,
-               totalCost,
-               average
+               totalCost
        });
 
 	return `${user.minionName} is now buying ${quantity}x ${itemNameFromID(

--- a/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
@@ -56,16 +56,14 @@ export async function buyingTripCommand(
 	await transactItems({ userID: user.id, itemsToRemove: cost });
 	await updateBankSetting('buy_cost_bank', cost);
 
-	await addSubTaskToActivityTask<BuyActivityTaskOptions>({
-		type: 'Buy',
-		itemID: osItem.id,
-		quantity,
-		totalCost,
-		average,
-		userID: user.id,
-		channelID: channelID.toString(),
-		duration
-	});
+       await addSubTaskToActivityTask<BuyActivityTaskOptions>({
+               type: 'Buy',
+               itemID: osItem.id,
+               quantity,
+               userID: user.id,
+               channelID: channelID.toString(),
+               duration
+       });
 
 	return `${user.minionName} is now buying ${quantity}x ${itemNameFromID(
 		osItem.id

--- a/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
@@ -62,7 +62,9 @@ export async function buyingTripCommand(
                quantity,
                userID: user.id,
                channelID: channelID.toString(),
-               duration
+               duration,
+               totalCost,
+               average
        });
 
 	return `${user.minionName} is now buying ${quantity}x ${itemNameFromID(

--- a/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/buyingTripCommand.ts
@@ -1,17 +1,16 @@
+import type { ChatInputCommandInteraction } from 'discord.js';
 import { Time } from 'e';
 import { Bank } from 'oldschooljs';
-import type { ChatInputCommandInteraction } from 'discord.js';
 
 import type { Buyable } from '../../../lib/data/buyables/buyables';
 import type { BuyActivityTaskOptions } from '../../../lib/types/minions';
 import { formatDuration, itemNameFromID } from '../../../lib/util';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
+import calculateShopBuyCost from '../../../lib/util/calculateShopBuyCost';
+import getOSItem from '../../../lib/util/getOSItem';
 import { handleMahojiConfirmation } from '../../../lib/util/handleMahojiConfirmation';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
-import { transactItems } from '../../../lib/util/TransactItems';
-import getOSItem from '../../../lib/util/getOSItem';
-import calculateShopBuyCost from '../../../lib/util/calculateShopBuyCost';
 
 export async function buyingTripCommand(
 	user: MUser,
@@ -33,9 +32,7 @@ export async function buyingTripCommand(
 	if (duration > maxTripLength) {
 		return `${user.minionName} can't go on a trip longer than ${formatDuration(
 			maxTripLength
-		)}, try a lower quantity. The highest amount you can buy is ${Math.floor(
-			maxTripLength / timePerItem
-		)}.`;
+		)}, try a lower quantity. The highest amount you can buy is ${Math.floor(maxTripLength / timePerItem)}.`;
 	}
 
 	const { total: totalCost, average } = calculateShopBuyCost(

--- a/src/tasks/minions/buyActivity.ts
+++ b/src/tasks/minions/buyActivity.ts
@@ -19,7 +19,8 @@ export const buyTask: MinionTask = {
                throw new Error(`No buyable found for item ${itemID}`);
        }
 
-       const { totalCost, average } = data;
+       const { totalCost } = data;
+       const average = Math.floor(totalCost / quantity);
 
        const loot = new Bank().add(itemID, quantity);
 	await transactItems({
@@ -35,9 +36,7 @@ export const buyTask: MinionTask = {
 	handleTripFinish(
 	user,
 	channelID,
-	`${user.minionName} finished buying ${quantity}x ${itemNameFromID(itemID)}. This cost ${totalCost.toLocaleString()} GP (avg ${Math.floor(
-	average
-	).toLocaleString()} ea).`,
+       `${user.minionName} finished buying ${quantity}x ${itemNameFromID(itemID)}. This cost ${totalCost.toLocaleString()} GP (avg ${average.toLocaleString()} ea).`,
 	undefined,
 	data,
 	loot

--- a/src/tasks/minions/buyActivity.ts
+++ b/src/tasks/minions/buyActivity.ts
@@ -5,6 +5,7 @@ import Buyables from '../../lib/data/buyables/buyables';
 import { itemNameFromID } from '../../lib/util';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
+import calculateShopBuyCost from '../../lib/util/calculateShopBuyCost';
 
 export const buyTask: MinionTask = {
 	type: 'Buy',
@@ -22,12 +23,20 @@ export const buyTask: MinionTask = {
                await updateBankSetting('buy_loot_bank', loot);
 
                const buyable = Buyables.find(b => itemNameFromID(itemID).toLowerCase() === b.name.toLowerCase());
-               const totalCost = buyable?.gpCost ? buyable.gpCost * quantity : 0;
+               const gpCost = buyable?.gpCost ?? 0;
+               const { total: totalCost, average } = calculateShopBuyCost(
+                       gpCost,
+                       quantity,
+                       buyable?.shopQuantity,
+                       buyable?.changePer
+               );
 
                handleTripFinish(
                        user,
                        channelID,
-                       `${user.minionName} finished buying ${quantity}x ${itemNameFromID(itemID)}. This cost ${totalCost.toLocaleString()} GP.`,
+                       `${user.minionName} finished buying ${quantity}x ${itemNameFromID(itemID)}. This cost ${totalCost.toLocaleString()} GP (avg ${Math.floor(
+                               average
+                       ).toLocaleString()} ea).`,
                        undefined,
                        data,
                        loot

--- a/src/tasks/minions/buyActivity.ts
+++ b/src/tasks/minions/buyActivity.ts
@@ -3,7 +3,6 @@ import { Bank } from 'oldschooljs';
 import type { BuyActivityTaskOptions } from '../../lib/types/minions';
 import Buyables from '../../lib/data/buyables/buyables';
 import { itemNameFromID } from '../../lib/util';
-import calculateShopBuyCost from '../../lib/util/calculateShopBuyCost';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
 
@@ -20,12 +19,7 @@ export const buyTask: MinionTask = {
                throw new Error(`No buyable found for item ${itemID}`);
        }
 
-       const { total: totalCost, average } = calculateShopBuyCost(
-               buyable.gpCost ?? 0,
-               quantity,
-               buyable.shopQuantity,
-               buyable.changePer
-       );
+       const { totalCost, average } = data;
 
        const loot = new Bank().add(itemID, quantity);
 	await transactItems({

--- a/src/tasks/minions/buyActivity.ts
+++ b/src/tasks/minions/buyActivity.ts
@@ -1,0 +1,36 @@
+import { Bank } from 'oldschooljs';
+
+import type { BuyActivityTaskOptions } from '../../lib/types/minions';
+import Buyables from '../../lib/data/buyables/buyables';
+import { itemNameFromID } from '../../lib/util';
+import { handleTripFinish } from '../../lib/util/handleTripFinish';
+import { updateBankSetting } from '../../lib/util/updateBankSetting';
+
+export const buyTask: MinionTask = {
+	type: 'Buy',
+       async run(data: BuyActivityTaskOptions) {
+               const { userID, channelID, itemID, quantity } = data;
+               const user = await mUserFetch(userID);
+
+               const loot = new Bank().add(itemID, quantity);
+               await transactItems({
+                       userID: user.id,
+                       itemsToAdd: loot,
+                       collectionLog: false
+               });
+
+               await updateBankSetting('buy_loot_bank', loot);
+
+               const buyable = Buyables.find(b => itemNameFromID(itemID).toLowerCase() === b.name.toLowerCase());
+               const totalCost = buyable?.gpCost ? buyable.gpCost * quantity : 0;
+
+               handleTripFinish(
+                       user,
+                       channelID,
+                       `${user.minionName} finished buying ${quantity}x ${itemNameFromID(itemID)}. This cost ${totalCost.toLocaleString()} GP.`,
+                       undefined,
+                       data,
+                       loot
+               );
+       }
+};

--- a/src/tasks/minions/buyActivity.ts
+++ b/src/tasks/minions/buyActivity.ts
@@ -7,30 +7,30 @@ import { updateBankSetting } from '../../lib/util/updateBankSetting';
 
 export const buyTask: MinionTask = {
 	type: 'Buy',
-       async run(data: BuyActivityTaskOptions) {
-               const { userID, channelID, itemID, quantity, totalCost, average } = data;
-               const user = await mUserFetch(userID);
+	async run(data: BuyActivityTaskOptions) {
+	const { userID, channelID, itemID, quantity, totalCost, average } = data;
+	const user = await mUserFetch(userID);
 
-               const loot = new Bank().add(itemID, quantity);
-               await transactItems({
-                       userID: user.id,
-                       itemsToAdd: loot,
-                       collectionLog: false
-               });
+	const loot = new Bank().add(itemID, quantity);
+	await transactItems({
+	userID: user.id,
+	itemsToAdd: loot,
+	collectionLog: false
+	});
 
-               await updateBankSetting('buy_loot_bank', loot);
+	await updateBankSetting('buy_loot_bank', loot);
 
 
 
-               handleTripFinish(
-                       user,
-                       channelID,
-                       `${user.minionName} finished buying ${quantity}x ${itemNameFromID(itemID)}. This cost ${totalCost.toLocaleString()} GP (avg ${Math.floor(
-                               average
-                       ).toLocaleString()} ea).`,
-                       undefined,
-                       data,
-                       loot
-               );
-       }
+	handleTripFinish(
+	user,
+	channelID,
+	`${user.minionName} finished buying ${quantity}x ${itemNameFromID(itemID)}. This cost ${totalCost.toLocaleString()} GP (avg ${Math.floor(
+	average
+	).toLocaleString()} ea).`,
+	undefined,
+	data,
+	loot
+	);
+	}
 };

--- a/src/tasks/minions/buyActivity.ts
+++ b/src/tasks/minions/buyActivity.ts
@@ -1,16 +1,14 @@
 import { Bank } from 'oldschooljs';
 
 import type { BuyActivityTaskOptions } from '../../lib/types/minions';
-import Buyables from '../../lib/data/buyables/buyables';
 import { itemNameFromID } from '../../lib/util';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
-import calculateShopBuyCost from '../../lib/util/calculateShopBuyCost';
 
 export const buyTask: MinionTask = {
 	type: 'Buy',
        async run(data: BuyActivityTaskOptions) {
-               const { userID, channelID, itemID, quantity } = data;
+               const { userID, channelID, itemID, quantity, totalCost, average } = data;
                const user = await mUserFetch(userID);
 
                const loot = new Bank().add(itemID, quantity);
@@ -22,14 +20,7 @@ export const buyTask: MinionTask = {
 
                await updateBankSetting('buy_loot_bank', loot);
 
-               const buyable = Buyables.find(b => itemNameFromID(itemID).toLowerCase() === b.name.toLowerCase());
-               const gpCost = buyable?.gpCost ?? 0;
-               const { total: totalCost, average } = calculateShopBuyCost(
-                       gpCost,
-                       quantity,
-                       buyable?.shopQuantity,
-                       buyable?.changePer
-               );
+
 
                handleTripFinish(
                        user,

--- a/tests/unit/calculateShopBuyCost.test.ts
+++ b/tests/unit/calculateShopBuyCost.test.ts
@@ -27,8 +27,8 @@ describe('calculateShopBuyCost', () => {
 
 	test('quantity exactly at shopQuantity', () => {
 		const result = calculateShopBuyCost(10, 5, 5, 10);
-		expect(result.total).toBe(105);
-		expect(result.average).toBe(21);
+		expect(result.total).toBe(60);
+		expect(result.average).toBe(12);
 	});
 
 	test('no price change', () => {

--- a/tests/unit/calculateShopBuyCost.test.ts
+++ b/tests/unit/calculateShopBuyCost.test.ts
@@ -4,17 +4,17 @@ import calculateShopBuyCost from '../../src/lib/util/calculateShopBuyCost';
 
 describe('calculateShopBuyCost', () => {
 	test('fixed price cost', () => {
-	  const result = calculateShopBuyCost(50, 3);
-	  expect(result).toEqual({ total: 150, average: 50 });
+		const result = calculateShopBuyCost(50, 3);
+		expect(result).toEqual({ total: 150, average: 50 });
 	});
 
 	test('variable cost within one world', () => {
-	  const result = calculateShopBuyCost(100, 3, 1000, 10);
-	  expect(result).toEqual({ total: 330, average: 110 });
+		const result = calculateShopBuyCost(100, 3, 1000, 10);
+		expect(result).toEqual({ total: 330, average: 110 });
 	});
 
 	test('variable cost with world hops', () => {
-	  const result = calculateShopBuyCost(100, 3, 2, 10);
-	  expect(result).toEqual({ total: 310, average: 103.33333333333333 });
+		const result = calculateShopBuyCost(100, 3, 2, 10);
+		expect(result).toEqual({ total: 310, average: 103.33333333333333 });
 	});
 });

--- a/tests/unit/calculateShopBuyCost.test.ts
+++ b/tests/unit/calculateShopBuyCost.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+
+import calculateShopBuyCost from '../../src/lib/util/calculateShopBuyCost';
+
+describe('calculateShopBuyCost', () => {
+	test('fixed price cost', () => {
+	  const result = calculateShopBuyCost(50, 3);
+	  expect(result).toEqual({ total: 150, average: 50 });
+	});
+
+	test('variable cost within one world', () => {
+	  const result = calculateShopBuyCost(100, 3, 1000, 10);
+	  expect(result).toEqual({ total: 330, average: 110 });
+	});
+
+	test('variable cost with world hops', () => {
+	  const result = calculateShopBuyCost(100, 3, 2, 10);
+	  expect(result).toEqual({ total: 310, average: 103.33333333333333 });
+	});
+});

--- a/tests/unit/calculateShopBuyCost.test.ts
+++ b/tests/unit/calculateShopBuyCost.test.ts
@@ -15,6 +15,24 @@ describe('calculateShopBuyCost', () => {
 
 	test('variable cost with world hops', () => {
 		const result = calculateShopBuyCost(100, 3, 2, 10);
-		expect(result).toEqual({ total: 310, average: 103.33333333333333 });
+		expect(result.total).toBe(310);
+		expect(result.average).toBeCloseTo(103.33, 2);
+	});
+
+	// edge cases
+	test('zero quantity returns zeroes', () => {
+		const result = calculateShopBuyCost(100, 0, 1000, 10);
+		expect(result).toEqual({ total: 0, average: 0 });
+	});
+
+	test('quantity exactly at shopQuantity', () => {
+		const result = calculateShopBuyCost(10, 5, 5, 10);
+		expect(result.total).toBe(105);
+		expect(result.average).toBe(21);
+	});
+
+	test('no price change', () => {
+		const result = calculateShopBuyCost(10, 5, 5, 0);
+		expect(result).toEqual({ total: 50, average: 10 });
 	});
 });

--- a/tests/unit/priceAbuses.test.ts
+++ b/tests/unit/priceAbuses.test.ts
@@ -69,7 +69,9 @@ describe('Price Abusing', () => {
 			i.gpCost !== undefined &&
 			i.itemCost === undefined &&
 			!isFunction(i.outputItems) &&
-			(!i.outputItems || i.outputItems.length === 1)
+			(!i.outputItems || i.outputItems.length === 1) &&
+			!i.shopQuantity &&
+			!i.quantityPerHour
 	);
 
 	test('Buyables', () => {

--- a/tests/unit/snapshots/banksnapshots.test.ts.snap
+++ b/tests/unit/snapshots/banksnapshots.test.ts.snap
@@ -4217,6 +4217,157 @@ exports[`OSB Buyables 1`] = `
     },
   },
   {
+    "changePer": 1,
+    "gpCost": 1,
+    "itemCost": {},
+    "name": "Arrow shaft",
+    "outputItems": {
+      "52": 1,
+    },
+    "quantityPerHour": 400000,
+    "shopQuantity": 1000,
+  },
+  {
+    "gpCost": 4,
+    "itemCost": {},
+    "name": "Copper ore",
+    "outputItems": {
+      "436": 1,
+    },
+    "quantityPerHour": 11000,
+  },
+  {
+    "gpCost": 4,
+    "itemCost": {},
+    "name": "Tin ore",
+    "outputItems": {
+      "438": 1,
+    },
+    "quantityPerHour": 11000,
+  },
+  {
+    "gpCost": 25,
+    "itemCost": {},
+    "name": "Iron ore",
+    "outputItems": {
+      "440": 1,
+    },
+    "quantityPerHour": 11000,
+  },
+  {
+    "gpCost": 243,
+    "itemCost": {},
+    "name": "Mithril ore",
+    "outputItems": {
+      "447": 1,
+    },
+    "quantityPerHour": 11000,
+  },
+  {
+    "gpCost": 112,
+    "itemCost": {},
+    "name": "Silver ore",
+    "outputItems": {
+      "442": 1,
+    },
+    "quantityPerHour": 11000,
+  },
+  {
+    "gpCost": 225,
+    "itemCost": {},
+    "name": "Gold ore",
+    "outputItems": {
+      "444": 1,
+    },
+    "quantityPerHour": 11000,
+  },
+  {
+    "gpCost": 67,
+    "itemCost": {},
+    "name": "Coal",
+    "outputItems": {
+      "453": 1,
+    },
+    "quantityPerHour": 11000,
+  },
+  {
+    "changePer": 0.1,
+    "gpCost": 400,
+    "itemCost": {},
+    "name": "Blood rune",
+    "outputItems": {
+      "565": 1,
+    },
+    "quantityPerHour": 100000,
+    "shopQuantity": 1000,
+  },
+  {
+    "changePer": 0.1,
+    "gpCost": 240,
+    "itemCost": {},
+    "name": "Law rune",
+    "outputItems": {
+      "563": 1,
+    },
+    "quantityPerHour": 100000,
+    "shopQuantity": 1000,
+  },
+  {
+    "changePer": 0.1,
+    "gpCost": 300,
+    "itemCost": {},
+    "name": "Soul rune",
+    "outputItems": {
+      "566": 1,
+    },
+    "quantityPerHour": 100000,
+    "shopQuantity": 1000,
+  },
+  {
+    "changePer": 0.1,
+    "gpCost": 50,
+    "itemCost": {},
+    "name": "Astral rune",
+    "outputItems": {
+      "9075": 1,
+    },
+    "quantityPerHour": 100000,
+    "shopQuantity": 1000,
+  },
+  {
+    "changePer": 0.1,
+    "gpCost": 180,
+    "itemCost": {},
+    "name": "Death rune",
+    "outputItems": {
+      "560": 1,
+    },
+    "quantityPerHour": 100000,
+    "shopQuantity": 1000,
+  },
+  {
+    "changePer": 0.1,
+    "gpCost": 180,
+    "itemCost": {},
+    "name": "Nature rune",
+    "outputItems": {
+      "561": 1,
+    },
+    "quantityPerHour": 100000,
+    "shopQuantity": 1000,
+  },
+  {
+    "changePer": 0.1,
+    "gpCost": 90,
+    "itemCost": {},
+    "name": "Chaos rune",
+    "outputItems": {
+      "562": 1,
+    },
+    "quantityPerHour": 100000,
+    "shopQuantity": 1000,
+  },
+  {
     "gpCost": 1320,
     "itemCost": {},
     "minigameScoreReq": [


### PR DESCRIPTION
## Summary
- support tracking buy trips via new `quantityPerHour` field
- handle minion `/buy` trips for any buyable with quantityPerHour
- show item name in minion status for buy trips
- implement generic `buyingTripCommand`
- add bf ores as the trip buyables
- show quantity in buy trip status
- move timed buyables to new file
- ensure trip buy check occurs after requirement validation

