### PR TITLE
Add Prescription goggles secondary saving benefit

### DIFF
--- a/docs/src/content/docs/osb/Minigames/mastering-mixology.md
+++ b/docs/src/content/docs/osb/Minigames/mastering-mixology.md
@@ -41,6 +41,8 @@ Spend your Mixology points using [[/minigames mastering_mixology buy]]. All rewa
 | Alchemist's amulet | 6,900 | 5,650 | 7,400 |
 | Aldarium | 80 | 60 | 90 |
 
+Prescription goggles provide a 10% chance to save a secondary ingredient while mixing potions. This also works on Torstols for Super combat potions and Anti-venom+, and on Irit when mixing Antidote++ (unf). They will not save Ashes when creating Serum 207.
+
 The potion packs have Herblore level requirements:
 
 - Apprentice potion pack requires **60 Herblore**.

--- a/docs/src/content/docs/osb/Skills/herblore.md
+++ b/docs/src/content/docs/osb/Skills/herblore.md
@@ -25,6 +25,8 @@ Making unfinished potions, cleaning herbs, and preparing secondary ingredients a
 
 - E.g. [[/mix name\:Crushed nest wesley\:True]]
 
+**Prescription goggles** - When worn, these give a 10% chance to save a secondary ingredient when mixing potions. This also applies to Torstols when creating Super combat potions or Anti-venom+, and to Irit when mixing Antidote++ (unf). Ashes are never saved when making Serum 207.
+
 ## Fastest route to 99
 
 1. [[/mix name\:Attack potion (3) quantity\:64]]

--- a/src/tasks/minions/herbloreActivity.ts
+++ b/src/tasks/minions/herbloreActivity.ts
@@ -1,5 +1,5 @@
 import { randInt } from 'e';
-import { Bank } from 'oldschooljs';
+import { Bank, Item } from 'oldschooljs';
 
 import { WildernessDiary, userhasDiaryTier } from '../../lib/diaries';
 import Herblore from '../../lib/skilling/skills/herblore/herblore';
@@ -8,6 +8,49 @@ import type { HerbloreActivityTaskOptions } from '../../lib/types/minions';
 import { percentChance } from '../../lib/util';
 import getOSItem from '../../lib/util/getOSItem';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
+
+const herbNames = [
+	'Guam leaf',
+	'Marrentill',
+	'Tarromin',
+	'Harralander',
+	'Ranarr weed',
+	'Toadflax',
+	'Irit leaf',
+	'Avantoe',
+	'Kwuarm',
+	'Snapdragon',
+	'Cadantine',
+	'Huasca',
+	'Lantadyme',
+	'Dwarf weed',
+	'Torstol'
+];
+
+function isSecondary(item: Item, mixableName: string): boolean {
+	if (item.name === 'Vial of water') return false;
+	if (item.name.toLowerCase().includes('(unf)')) return false;
+	if (mixableName === 'Serum 207 (3)' && item.name === 'Ashes') return false;
+
+	if (herbNames.includes(item.name)) {
+		if (
+			item.name === 'Torstol' &&
+			(mixableName === 'Super combat potion (4)' || mixableName === 'Anti-venom+(4)')
+		) {
+			return true;
+		}
+		if (
+			item.name === 'Irit leaf' &&
+			mixableName.includes('Antidote++') &&
+			mixableName.toLowerCase().includes('unf')
+		) {
+			return true;
+		}
+		return false;
+	}
+
+	return true;
+}
 
 export const herbloreTask: MinionTask = {
 	type: 'Herblore',
@@ -40,15 +83,33 @@ export const herbloreTask: MinionTask = {
 			outputQuantity = scales;
 		}
 
+		const savedItems = new Bank();
+		const hasGoggles = user.gear.skilling.hasEquipped('Prescription goggles');
+		if (hasGoggles) {
+			for (let i = 0; i < quantity; i++) {
+				for (const [id, qty] of mixableItem.inputItems.items()) {
+					const item = getOSItem(id);
+					if (!isSecondary(item, mixableItem.item.name)) continue;
+					for (let q = 0; q < qty; q++) {
+						if (percentChance(10)) {
+							savedItems.add(id, 1);
+						}
+					}
+				}
+			}
+		}
+
 		const xpRes = await user.addXP({ skillName: SkillsEnum.Herblore, amount: xpReceived, duration });
-		const loot = new Bank().add(mixableItem.item.id, outputQuantity);
+		const loot = new Bank().add(mixableItem.item.id, outputQuantity).add(savedItems);
 
 		await transactItems({ userID: user.id, collectionLog: true, itemsToAdd: loot });
+
+		const savedStr = savedItems.length > 0 ? ` Your prescription goggles saved ${savedItems}.` : '';
 
 		handleTripFinish(
 			user,
 			channelID,
-			`${user}, ${user.minionName} finished making ${outputQuantity}x ${mixableItem.item.name}. ${xpRes}`,
+			`${user}, ${user.minionName} finished making ${outputQuantity}x ${mixableItem.item.name}. ${xpRes}.${savedStr}`,
 			undefined,
 			data,
 			loot


### PR DESCRIPTION
## Summary
- add Prescription goggles effect saving secondaries in herblore
- document goggles in herblore guide and Mastering Mixology page

