### PR TITLE
Add command duel gambling option

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -333,6 +333,7 @@ model User {
   bank_sort_method           String?            @db.VarChar(16)
   bank_sort_weightings       Json               @default("{}") @db.Json
   gambling_lockout_expiry    DateTime?
+  command_lockout_expiry     DateTime?
   icon_pack_id               String?
 
   // Skills

--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -966,7 +966,7 @@ async function srcMUserFetch(userID: string, updates?: Prisma.UserUpdateInput) {
 	if (!user) {
 		return srcMUserFetch(userID, {});
 	}
-	partialUserCache.set(userID, pick(user, ['bitfield', 'minion_hasBought', 'badges']));
+	partialUserCache.set(userID, pick(user, ['bitfield', 'minion_hasBought', 'badges', 'command_lockout_expiry']));
 	return new MUserClass(user);
 }
 

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -5,7 +5,7 @@ import { LRUCache } from 'lru-cache';
 
 export const perkTierCache = new Map<string, 0 | PerkTier>();
 
-export type PartialUser = Pick<User, 'bitfield' | 'badges' | 'minion_hasBought'>;
+export type PartialUser = Pick<User, 'bitfield' | 'badges' | 'minion_hasBought' | 'command_lockout_expiry'>;
 export const partialUserCache = new Map<string, PartialUser>();
 
 type CachedGuild = Pick<Guild, 'disabledCommands' | 'id' | 'petchannel' | 'staffOnlyChannels'>;

--- a/src/lib/util/parseDuration.ts
+++ b/src/lib/util/parseDuration.ts
@@ -1,0 +1,18 @@
+import { Time } from 'e';
+
+const regex = /(\d+)([smhd])/gi;
+
+export function parseDuration(str: string): number | null {
+	let duration = 0;
+	let match: RegExpExecArray | null;
+	while ((match = regex.exec(str))) {
+		const num = parseInt(match[1]);
+		const unit = match[2].toLowerCase();
+		if (unit === 's') duration += num * Time.Second;
+		else if (unit === 'm') duration += num * Time.Minute;
+		else if (unit === 'h') duration += num * Time.Hour;
+		else if (unit === 'd') duration += num * Time.Day;
+		else return null;
+	}
+	return duration > 0 ? duration : null;
+}

--- a/src/mahoji/lib/inhibitors.ts
+++ b/src/mahoji/lib/inhibitors.ts
@@ -166,6 +166,20 @@ const inhibitors: Inhibitor[] = [
 		canBeDisabled: true
 	},
 	{
+		name: 'commandLocked',
+		run: ({ cachedUser }) => {
+			if (cachedUser?.command_lockout_expiry && cachedUser.command_lockout_expiry.getTime() > Date.now()) {
+				return {
+					content: `You are command locked for another ${formatDuration(
+						cachedUser.command_lockout_expiry.getTime() - Date.now()
+					)}`
+				};
+			}
+			return false;
+		},
+		canBeDisabled: false
+	},
+	{
 		name: 'blacklisted',
 		run: ({ userID, guild }) => {
 			if (BLACKLISTED_USERS.has(userID)) {


### PR DESCRIPTION
## Summary
- add `command_lockout_expiry` column
- implement command locking inhibitor
- add `commands` subcommand under `/gamble`
- add small duration parser utility

## Testing
- `pnpm test` *(fails: Error: Failed to resolve entry for package "oldschooljs")*

------
https://chatgpt.com/codex/tasks/task_e_68506a3290ac83269e0504b04cbe5bc8