### PR TITLE
Add scarred extract support for Dark Altar runecrafting

### DIFF
--- a/src/lib/minions/functions/darkAltarCommand.ts
+++ b/src/lib/minions/functions/darkAltarCommand.ts
@@ -1,10 +1,11 @@
 import { Time, increaseNumByPercent, reduceNumByPercent } from 'e';
+import { Bank } from 'oldschooljs';
 import { SkillsEnum } from 'oldschooljs/dist/constants';
 
 import { userHasGracefulEquipped } from '../../../mahoji/mahojiSettings';
 import { KourendKebosDiary, userhasDiaryTier } from '../../diaries';
 import type { DarkAltarOptions } from '../../types/minions';
-import { formatDuration, hasSkillReqs } from '../../util';
+import { formatDuration, hasSkillReqs, updateBankSetting } from '../../util';
 import addSubTaskToActivityTask from '../../util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../util/calcMaxTripLength';
 import getOSItem from '../../util/getOSItem';
@@ -30,7 +31,7 @@ const gracefulPenalty = 20;
 const agilityPenalty = 35;
 const mediumDiaryBoost = 20;
 
-export async function darkAltarCommand({ user, channelID, name }: { user: MUser; channelID: string; name: string }) {
+export async function darkAltarCommand({ user, channelID, name, extracts }: { user: MUser; channelID: string; name: string; extracts?: boolean }) {
 	const stats = user.skillsAsLevels;
 	if (!['blood', 'soul'].includes(name.split(' ')[0])) return 'Invalid rune.';
 	const [hasReqs, neededReqs] = hasSkillReqs(user, {
@@ -72,22 +73,44 @@ export async function darkAltarCommand({ user, channelID, name }: { user: MUser;
 		timePerRune = increaseNumByPercent(timePerRune, agilityPenalty);
 	}
 
-	const maxTripLength = calcMaxTripLength(user, 'DarkAltar');
-	const quantity = Math.floor(maxTripLength / timePerRune);
+       const maxTripLength = calcMaxTripLength(user, 'DarkAltar');
+       let quantity = Math.floor(maxTripLength / timePerRune);
+       let duration = maxTripLength;
+       const totalCost = new Bank();
+       if (extracts) {
+               const extractsOwned = user.bank.amount('Scarred extract');
+               quantity = Math.min(quantity, extractsOwned);
+               if (extractsOwned === 0 || quantity === 0) {
+                       return "You don't have enough Scarred extracts to craft these runes.";
+               }
+               duration = quantity * timePerRune;
+               totalCost.add('Scarred extract', quantity);
+               if (!user.owns(totalCost)) return `You don't own: ${totalCost}.`;
+       }
 
-	await addSubTaskToActivityTask<DarkAltarOptions>({
-		userID: user.id,
-		channelID: channelID.toString(),
-		quantity,
-		duration: maxTripLength,
-		type: 'DarkAltar',
-		hasElite: hasEliteDiary,
-		rune
-	});
+       if (totalCost.length > 0) {
+               await user.removeItemsFromBank(totalCost);
+               updateBankSetting('runecraft_cost', totalCost);
+       }
 
-	let response = `${user.minionName} is now going to Runecraft ${runeData.item.name}'s for ${formatDuration(
-		maxTripLength
-	)} at the Dark altar.`;
+       await addSubTaskToActivityTask<DarkAltarOptions>({
+               userID: user.id,
+               channelID: channelID.toString(),
+               quantity,
+               duration,
+               type: 'DarkAltar',
+               hasElite: hasEliteDiary,
+               rune,
+               useExtracts: extracts
+       });
+
+       let response = `${user.minionName} is now going to Runecraft ${runeData.item.name}'s for ${formatDuration(
+               duration
+       )} at the Dark altar.`;
+
+       if (extracts) {
+               response += `\nYou will use ${quantity}x Scarred extract during this trip.`;
+       }
 
 	if (boosts.length > 0) {
 		response += `\n\n**Boosts:** ${boosts.join(', ')}.`;

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -99,10 +99,11 @@ export interface TiaraRunecraftActivityTaskOptions extends ActivityTaskOptions {
 }
 
 export interface DarkAltarOptions extends ActivityTaskOptions {
-	type: 'DarkAltar';
-	quantity: number;
-	hasElite: boolean;
-	rune: 'blood' | 'soul';
+        type: 'DarkAltar';
+        quantity: number;
+        hasElite: boolean;
+       rune: 'blood' | 'soul';
+       useExtracts?: boolean;
 }
 
 export interface OuraniaAltarOptions extends ActivityTaskOptions {

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -565,12 +565,14 @@ export function minionStatus(user: MUser) {
 			return `${name} is currently hunting Chompy Birds! ${formattedDuration}`;
 		}
 
-		case 'DarkAltar': {
-			const data = currentTask as DarkAltarOptions;
-			return `${name} is currently runecrafting ${toTitleCase(
-				data.rune
-			)} runes at the Dark Altar. ${formattedDuration}`;
-		}
+               case 'DarkAltar': {
+                       const data = currentTask as DarkAltarOptions;
+                       return `${name} is currently runecrafting ${toTitleCase(
+                               data.rune
+                       )} runes at the Dark Altar${
+                               data.useExtracts ? ' with extracts' : ''
+                       }. ${formattedDuration}`;
+               }
 		case 'OuraniaAltar': {
 			return `${name} is currently runecrafting at the Ourania Altar. ${formattedDuration}`;
 		}

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -275,10 +275,13 @@ const tripHandlers = {
 			warriors_guild: { action: 'cyclops', quantity: data.quantity }
 		})
 	},
-	[activity_type_enum.DarkAltar]: {
-		commandName: 'runecraft',
-		args: (data: DarkAltarOptions) => ({ rune: `${darkAltarRunes[data.rune].item.name} (zeah)` })
-	},
+       [activity_type_enum.DarkAltar]: {
+               commandName: 'runecraft',
+               args: (data: DarkAltarOptions) => ({
+                       rune: `${darkAltarRunes[data.rune].item.name} (zeah)`,
+                       extracts: data.useExtracts
+               })
+       },
 	[activity_type_enum.OuraniaAltar]: {
 		commandName: 'runecraft',
 		args: (data: OuraniaAltarOptions) => ({

--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -117,9 +117,9 @@ export const runecraftCommand: OSBMahojiCommand = {
 			return ouraniaAltarStartCommand({ user, channelID, quantity, usestams, daeyalt_essence });
 		}
 
-		if (rune.includes('(zeah)')) {
-			return darkAltarCommand({ user, channelID, name: rune });
-		}
+               if (rune.includes('(zeah)')) {
+                       return darkAltarCommand({ user, channelID, name: rune, extracts });
+               }
 
 		const runeObj = Runecraft.Runes.find(
 			_rune => stringMatches(_rune.name, rune) || stringMatches(_rune.name.split(' ')[0], rune)

--- a/src/tasks/minions/darkAltarActivity.ts
+++ b/src/tasks/minions/darkAltarActivity.ts
@@ -12,7 +12,7 @@ import { handleTripFinish } from '../../lib/util/handleTripFinish';
 export const darkAltarTask: MinionTask = {
 	type: 'DarkAltar',
 	async run(data: DarkAltarOptions) {
-		const { quantity, userID, channelID, duration, hasElite, rune } = data;
+               const { quantity, userID, channelID, duration, hasElite, rune, useExtracts } = data;
 		const user = await mUserFetch(userID);
 
 		const runeData = darkAltarRunes[rune];
@@ -48,11 +48,17 @@ export const darkAltarTask: MinionTask = {
 		runeQuantity += raimentQuantity;
 		bonusQuantity += raimentQuantity;
 
-		let bonusBlood = 0;
-		if (rune === 'blood') {
-			bonusBlood = await bloodEssence(user, quantity);
-			runeQuantity += bonusBlood;
-		}
+               let bonusBlood = 0;
+               if (rune === 'blood') {
+                       bonusBlood = await bloodEssence(user, quantity);
+                       runeQuantity += bonusBlood;
+               }
+
+               let extractBonus = 0;
+               if (useExtracts) {
+                       extractBonus = 60 * quantity;
+                       runeQuantity += extractBonus;
+               }
 
 		const loot = new Bank().add(runeData.item.id, runeQuantity);
 		const { petDropRate } = skillingPetDropRate(user, SkillsEnum.Runecraft, runeData.petChance);
@@ -68,9 +74,13 @@ export const darkAltarTask: MinionTask = {
 			str += ` **Bonus Quantity:** ${bonusQuantity.toLocaleString()}`;
 		}
 
-		if (bonusBlood > 0) {
-			str += ` **Blood essence Quantity:** ${bonusBlood.toLocaleString()}`;
-		}
+               if (bonusBlood > 0) {
+                       str += ` **Blood essence Quantity:** ${bonusBlood.toLocaleString()}`;
+               }
+
+               if (useExtracts) {
+                       str += ` **Extract bonus:** ${extractBonus.toLocaleString()}`;
+               }
 
 		if (loot.amount('Rift guardian') > 0) {
 			globalClient.emit(


### PR DESCRIPTION
## Summary
- allow dark altar runs to use Scarred extracts
- track extracts usage in command args and minion status
- award extract bonus when crafting at the Dark Altar
- update repeat trip logic for extracts
