### PR TITLE
Add tame breeding cooldown and graveyard

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -758,6 +758,9 @@ model Tame {
   last_activity_date   DateTime? @db.Timestamp(6)
   levels_from_egg_feed Int?
 
+  breeding_cooldown_until DateTime? @db.Timestamp(6)
+  is_dead                 Boolean   @default(false)
+
   custom_icon_id String? @db.VarChar(19)
 
   tame_activity TameActivity[]

--- a/src/lib/tames.ts
+++ b/src/lib/tames.ts
@@ -19,9 +19,12 @@ import itemID from './util/itemID';
 import resolveItems from './util/resolveItems';
 
 export enum TameSpeciesID {
-	Igne = 1,
-	Monkey = 2,
-	Eagle = 3
+        Igne = 1,
+        Monkey = 2,
+        Eagle = 3,
+        IgneMonkey = 102,
+        IgneEagle = 103,
+        MonkeyEagle = 203
 }
 
 interface FeedableItem {
@@ -539,29 +542,83 @@ export const tameSpecies: Species[] = [
 			.add('Astral rune', 600)
 			.add('Coins', 10_000_000)
 	},
-	{
-		id: TameSpeciesID.Eagle,
-		type: TameType.Support,
-		name: 'Eagle',
-		variants: [1, 2, 3],
-		shinyVariant: 4,
-		shinyChance: 60,
-		combatLevelRange: [5, 25],
-		artisanLevelRange: [1, 10],
-		supportLevelRange: [50, 100],
-		gathererLevelRange: [20, 40],
-		relevantLevelCategory: 'support',
-		hatchTime: Time.Hour * 4.5,
-		egg: getOSItem('Eagle egg'),
-		emoji: '<:EagleEgg:1201712371371085894>',
-		emojiID: '1201712371371085894',
-		mergingCost: new Bank()
-			.add('Solite', 150)
-			.add('Soul rune', 2500)
-			.add('Elder rune', 100)
-			.add('Astral rune', 600)
-			.add('Coins', 10_000_000)
-	}
+        {
+                id: TameSpeciesID.Eagle,
+                type: TameType.Support,
+                name: 'Eagle',
+                variants: [1, 2, 3],
+                shinyVariant: 4,
+                shinyChance: 60,
+                combatLevelRange: [5, 25],
+                artisanLevelRange: [1, 10],
+                supportLevelRange: [50, 100],
+                gathererLevelRange: [20, 40],
+                relevantLevelCategory: 'support',
+                hatchTime: Time.Hour * 4.5,
+                egg: getOSItem('Eagle egg'),
+                emoji: '<:EagleEgg:1201712371371085894>',
+                emojiID: '1201712371371085894',
+                mergingCost: new Bank()
+                        .add('Solite', 150)
+                        .add('Soul rune', 2500)
+                        .add('Elder rune', 100)
+                        .add('Astral rune', 600)
+                        .add('Coins', 10_000_000)
+        },
+        {
+                id: TameSpeciesID.IgneMonkey,
+                type: TameType.Combat,
+                name: 'Igne-Monkey Hybrid',
+                variants: [1],
+                shinyVariant: 2,
+                shinyChance: 45,
+                combatLevelRange: [40, 60],
+                artisanLevelRange: [1, 10],
+                supportLevelRange: [1, 20],
+                gathererLevelRange: [40, 80],
+                relevantLevelCategory: 'combat',
+                hatchTime: Time.Hour * 18,
+                egg: getOSItem('Monkey egg'),
+                mergingCost: new Bank(),
+                emoji: '<:dragonEgg:858948148641660948>',
+                emojiID: '858948148641660948'
+        },
+        {
+                id: TameSpeciesID.IgneEagle,
+                type: TameType.Combat,
+                name: 'Igne-Eagle Hybrid',
+                variants: [1],
+                shinyVariant: 2,
+                shinyChance: 45,
+                combatLevelRange: [50, 70],
+                artisanLevelRange: [1, 10],
+                supportLevelRange: [40, 80],
+                gathererLevelRange: [10, 30],
+                relevantLevelCategory: 'combat',
+                hatchTime: Time.Hour * 18,
+                egg: getOSItem('Eagle egg'),
+                mergingCost: new Bank(),
+                emoji: '<:dragonEgg:858948148641660948>',
+                emojiID: '858948148641660948'
+        },
+        {
+                id: TameSpeciesID.MonkeyEagle,
+                type: TameType.Gatherer,
+                name: 'Monkey-Eagle Hybrid',
+                variants: [1],
+                shinyVariant: 2,
+                shinyChance: 60,
+                combatLevelRange: [10, 30],
+                artisanLevelRange: [1, 10],
+                supportLevelRange: [40, 80],
+                gathererLevelRange: [60, 100],
+                relevantLevelCategory: 'gatherer',
+                hatchTime: Time.Hour * 6,
+                egg: getOSItem('Monkey egg'),
+                mergingCost: new Bank(),
+                emoji: '<:monkey_egg:883326001445224488>',
+                emojiID: '883326001445224488'
+        }
 ];
 
 export interface Species {

--- a/src/lib/tames/breeding.ts
+++ b/src/lib/tames/breeding.ts
@@ -1,0 +1,136 @@
+import { tame_growth, type Tame } from '@prisma/client';
+import { Time, roll } from 'e';
+
+import { prisma } from '../..';
+import { tameSpecies } from '../tames';
+import type { MUser } from '../MUser';
+
+function isAdult(tame: Tame) {
+       return tame.growth_stage === tame_growth.adult;
+}
+
+function nextBreedDate(tame: Tame) {
+       return tame.breeding_cooldown_until?.getTime() ?? 0;
+}
+
+const hybridIDMap: Record<string, number> = {
+       '1_2': 102,
+       '1_3': 103,
+       '2_3': 203
+};
+
+function getHybridID(id1: number, id2: number): number | undefined {
+       const [a, b] = [id1, id2].sort((x, y) => x - y);
+       return hybridIDMap[`${a}_${b}`];
+}
+
+export async function breedTames(user: MUser, parent1: Tame, parent2: Tame) {
+  if (parent1.id === parent2.id) {
+    return "You must select two different tames.";
+  }
+  if (parent1.user_id !== user.id || parent2.user_id !== user.id) {
+    return "Both tames must belong to you.";
+  }
+  if (parent1.is_dead || parent2.is_dead) {
+    return 'One of those tames is dead and cannot breed.';
+  }
+  const species1 = tameSpecies.find(s => s.id === parent1.species_id)!;
+  const species2 = tameSpecies.find(s => s.id === parent2.species_id)!;
+  if (species1.id === species2.id) {
+    return 'Parents must be of different species.';
+  }
+  // Age checks
+  const stages = [parent1.growth_stage, parent2.growth_stage];
+  if (stages.includes(tame_growth.baby) && stages.includes(tame_growth.baby)) {
+    return "Check this user's internet history.";
+  }
+  if (
+    (stages.includes(tame_growth.baby) && stages.includes(tame_growth.adult))
+  ) {
+    return 'This user has been reported to Discord and local authorities.';
+  }
+  if (
+    (stages.includes(tame_growth.juvenile) && stages.includes(tame_growth.adult))
+  ) {
+    return 'The teen tries to impress the adult, but the adult isn\'t interested.';
+  }
+  if (
+    (stages.includes(tame_growth.juvenile) && stages.includes(tame_growth.baby))
+  ) {
+    return 'The teen babysits the baby tame. No one is in the mood for breeding.';
+  }
+  if (!isAdult(parent1) || !isAdult(parent2)) {
+    return 'Both tames must be adults.';
+  }
+  const now = Date.now();
+  if (now < nextBreedDate(parent1) || now < nextBreedDate(parent2)) {
+    return 'One of these tames is still recovering from a previous breeding.';
+  }
+
+  // Offspring shiny logic
+  const shiny1 = parent1.species_variant === species1.shinyVariant;
+  const shiny2 = parent2.species_variant === species2.shinyVariant;
+  let shiny = false;
+  if (shiny1 && shiny2) {
+    shiny = true;
+  } else if (shiny1 || shiny2) {
+    shiny = roll(Math.floor(species1.shinyChance / 2));
+  } else {
+    shiny = roll(species1.shinyChance);
+  }
+
+  const hybridName = `${species1.name.slice(0, 3)}-${species2.name.slice(-3)}`;
+
+  const hybridID = getHybridID(species1.id, species2.id) ?? species1.id;
+
+  const newTame = await prisma.tame.create({
+    data: {
+      user_id: user.id,
+      species_id: hybridID,
+      growth_stage: tame_growth.baby,
+      growth_percent: 0,
+      species_variant: shiny ? species1.shinyVariant : species1.variants[0],
+      max_total_loot: {},
+      fed_items: {},
+      max_support_level: Math.floor((parent1.max_support_level + parent2.max_support_level) / 2),
+      max_gatherer_level: Math.floor((parent1.max_gatherer_level + parent2.max_gatherer_level) / 2),
+      max_artisan_level: Math.floor((parent1.max_artisan_level + parent2.max_artisan_level) / 2),
+      max_combat_level: Math.floor((parent1.max_combat_level + parent2.max_combat_level) / 2),
+      nickname: hybridName
+    }
+  });
+
+  const deaths: string[] = [];
+
+  const parent1Died = roll(4) !== 1;
+  const parent2Died = roll(4) !== 1;
+
+  await prisma.tame.update({
+    where: { id: parent1.id },
+    data: {
+      breeding_cooldown_until: new Date(now + Time.Week),
+      is_dead: parent1Died
+    }
+  });
+
+  await prisma.tame.update({
+    where: { id: parent2.id },
+    data: {
+      breeding_cooldown_until: new Date(now + Time.Week),
+      is_dead: parent2Died
+    }
+  });
+
+  if (parent1Died) {
+    deaths.push(`${parent1.nickname ?? species1.name} has died from exhaustion.`);
+  }
+  if (parent2Died) {
+    deaths.push(`${parent2.nickname ?? species2.name} has died from exhaustion.`);
+  }
+
+  let msg = `A new hybrid tame ${hybridName} was born${shiny ? ' and it\'s shiny!' : '!'}`;
+  if (deaths.length > 0) {
+    msg += `\n${deaths.join('\n')}`;
+  }
+  return msg;
+}

--- a/src/tasks/tames/tameTasks.ts
+++ b/src/tasks/tames/tameTasks.ts
@@ -100,10 +100,10 @@ export async function handleFinish({
 }
 
 export const arbitraryTameActivities: ArbitraryTameActivity[] = [
-	{
-		name: 'Tempoross',
-		id: 'Tempoross',
-		allowedTames: [TameSpeciesID.Monkey],
+        {
+                name: 'Tempoross',
+                id: 'Tempoross',
+                allowedTames: [TameSpeciesID.Monkey, TameSpeciesID.IgneMonkey, TameSpeciesID.MonkeyEagle],
 		run: async ({ handleFinish, user, duration, tame, previousTameCL, activity }) => {
 			const quantity = Math.ceil(duration / (Time.Minute * 5));
 			const loot = getTemporossLoot(quantity, tame.maxGathererLevel + 15, previousTameCL);
@@ -116,10 +116,10 @@ export const arbitraryTameActivities: ArbitraryTameActivity[] = [
 			});
 		}
 	},
-	{
-		name: 'Wintertodt',
-		id: 'Wintertodt',
-		allowedTames: [TameSpeciesID.Igne],
+        {
+                name: 'Wintertodt',
+                id: 'Wintertodt',
+                allowedTames: [TameSpeciesID.Igne, TameSpeciesID.IgneMonkey, TameSpeciesID.IgneEagle],
 		run: async ({ handleFinish, user, duration, tame, activity }) => {
 			const quantity = Math.ceil(duration / (Time.Minute * 5));
 			const loot = new Bank();


### PR DESCRIPTION
## Summary
- add new `breeding_cooldown_until` and `is_dead` fields in prisma
- persist breeding cooldowns and mark parents as dead
- hybrid species definitions and support for mutated tames
- add `/tames graveyard` subcommand
- exclude dead tames from autocomplete and update allowed species for activities
