### PR TITLE
Add toggleable Daily/TOG Reminders

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -263,8 +263,11 @@ export enum BitField {
 	DisableClueButtons = 38,
 	DisableAutoSlayButton = 39,
 	DisableHighPeakTimeWarning = 40,
-	DisableOpenableNames = 41,
-	ShowDetailedInfo = 42
+        DisableOpenableNames = 41,
+       ShowDetailedInfo = 42,
+       DisableDailyReminderDMs = 43,
+       DisableTearsOfGuthixReminderDMs = 44,
+       DisableTearsOfGuthixButton = 45
 }
 
 interface BitFieldData {
@@ -363,11 +366,26 @@ export const BitFieldData: Record<BitField, BitFieldData> = {
 		protected: false,
 		userConfigurable: true
 	},
-	[BitField.ShowDetailedInfo]: {
-		name: 'Show Detailed Info',
-		protected: false,
-		userConfigurable: true
-	}
+        [BitField.ShowDetailedInfo]: {
+                name: 'Show Detailed Info',
+                protected: false,
+                userConfigurable: true
+        },
+        [BitField.DisableDailyReminderDMs]: {
+                name: 'Disable Daily Reminder DMs',
+                protected: false,
+                userConfigurable: true
+        },
+       [BitField.DisableTearsOfGuthixReminderDMs]: {
+               name: 'Disable Tears of Guthix Reminder DMs',
+               protected: false,
+               userConfigurable: true
+       },
+       [BitField.DisableTearsOfGuthixButton]: {
+               name: 'Disable Tears of Guthix Trip Button',
+               protected: false,
+               userConfigurable: true
+       }
 } as const;
 
 export const BadgesEnum = {

--- a/src/lib/tickers.ts
+++ b/src/lib/tickers.ts
@@ -122,9 +122,9 @@ export const tickers: {
 		cb: async () => {
 			await processPendingActivities();
 		}
-	},
-	{
-		name: 'daily_reminders',
+        },
+        {
+                name: 'daily_reminders',
 		interval: Time.Minute * 3,
 		startupWait: Time.Minute,
 		timer: null,
@@ -134,7 +134,7 @@ export const tickers: {
 SELECT users.id, user_stats.last_daily_timestamp
 FROM users
 JOIN user_stats ON users.id::bigint = user_stats.user_id
-WHERE bitfield && '{2,3,4,5,6,7,8,12,21,24}'::int[] AND user_stats."last_daily_timestamp" != -1 AND to_timestamp(user_stats."last_daily_timestamp" / 1000) < now() - INTERVAL '12 hours';
+WHERE bitfield && '{2,3,4,5,6,7,8,12,21,24}'::int[] AND user_stats."last_daily_timestamp" != -1 AND NOT bitfield @> '{43}'::int[] AND to_timestamp(user_stats."last_daily_timestamp" / 1000) < now() - INTERVAL '12 hours';
 `
 			);
 			const dailyDMButton = new ButtonBuilder()
@@ -157,12 +157,50 @@ WHERE bitfield && '{2,3,4,5,6,7,8,12,21,24}'::int[] AND user_stats."last_daily_t
 					{}
 				);
 				const user = await globalClient.fetchUser(row.id);
-				await user.send({ content: str, components: makeComponents(components) }).catch(noOp);
-			}
-		}
-	},
-	{
-		name: 'wilderness_peak_times',
+                        await user.send({ content: str, components: makeComponents(components) }).catch(noOp);
+                        }
+                }
+        },
+        {
+                name: 'tears_of_guthix_reminders',
+                interval: Time.Hour,
+                startupWait: Time.Minute * 2,
+                timer: null,
+                cb: async () => {
+                        const result = await prisma.$queryRawUnsafe<{ id: string; last_tears_of_guthix_timestamp: bigint }[]>(
+                                `
+SELECT users.id, user_stats.last_tears_of_guthix_timestamp
+FROM users
+JOIN user_stats ON users.id::bigint = user_stats.user_id
+WHERE bitfield && '{2,3,4,5,6,7,8,12,21,24}'::int[] AND user_stats."last_tears_of_guthix_timestamp" != -1 AND user_stats."last_tears_of_guthix_timestamp" != 0 AND NOT bitfield @> '{44}'::int[] AND to_timestamp(user_stats."last_tears_of_guthix_timestamp" / 1000) < now() - INTERVAL '7 days';
+`
+                        );
+                        const togButton = new ButtonBuilder()
+                                .setCustomId('START_TOG')
+                                .setLabel('Start Tears of Guthix')
+                                .setEmoji('🐍')
+                                .setStyle(ButtonStyle.Secondary);
+                        const components = [togButton];
+                        const str = 'Your Tears of Guthix is ready!';
+
+                        for (const row of result.values()) {
+                                if (!globalConfig.isProduction) continue;
+                                if (Number(row.last_tears_of_guthix_timestamp) === -1) continue;
+
+                                await userStatsUpdate(
+                                        row.id,
+                                        {
+                                                last_tears_of_guthix_timestamp: -1
+                                        },
+                                        {}
+                                );
+                                const user = await globalClient.fetchUser(row.id);
+                                await user.send({ content: str, components: makeComponents(components) }).catch(noOp);
+                        }
+                }
+        },
+        {
+                name: 'wilderness_peak_times',
 		timer: null,
 		interval: Time.Hour * 24,
 		cb: async () => {

--- a/src/lib/util/globalInteractions.ts
+++ b/src/lib/util/globalInteractions.ts
@@ -46,10 +46,11 @@ const globalInteractionActions = [
 	'FARMING_CONTRACT_EASIER',
 	'OPEN_SEED_PACK',
 	'BUY_MINION',
-	'BUY_BINGO_TICKET',
-	'NEW_SLAYER_TASK',
-	'DO_SHOOTING_STAR',
-	'CHECK_TOA'
+        'BUY_BINGO_TICKET',
+        'NEW_SLAYER_TASK',
+        'DO_SHOOTING_STAR',
+        'CHECK_TOA',
+        'START_TOG'
 ] as const;
 
 type GlobalInteractionAction = (typeof globalInteractionActions)[number];
@@ -86,11 +87,19 @@ export function makeAutoContractButton() {
 }
 
 export function makeRepeatTripButton() {
-	return new ButtonBuilder()
-		.setCustomId('REPEAT_TRIP')
-		.setLabel('Repeat Trip')
-		.setStyle(ButtonStyle.Secondary)
-		.setEmoji('🔁');
+        return new ButtonBuilder()
+                .setCustomId('REPEAT_TRIP')
+                .setLabel('Repeat Trip')
+                .setStyle(ButtonStyle.Secondary)
+                .setEmoji('🔁');
+}
+
+export function makeTearsOfGuthixButton() {
+        return new ButtonBuilder()
+                .setCustomId('START_TOG')
+                .setLabel('Start Tears of Guthix')
+                .setStyle(ButtonStyle.Secondary)
+                .setEmoji('🐍');
 }
 
 export function makeBirdHouseTripButton() {
@@ -560,23 +569,31 @@ export async function interactionHook(interaction: Interaction) {
 				...options
 			});
 		}
-		case 'DO_SHOOTING_STAR': {
-			const star = starCache.get(user.id);
-			starCache.delete(user.id);
-			if (star && star.expiry > Date.now()) {
-				const str = await shootingStarsCommand(interaction.channelId, user, star);
-				return interactionReply(interaction, str);
-			}
-			return interactionReply(interaction, {
-				content: `${
-					star && star.expiry < Date.now()
-						? 'The Crashed Star has expired!'
-						: `That Crashed Star was not discovered by ${user.minionName}.`
-				}`,
-				ephemeral: true
-			});
-		}
-		default: {
-		}
-	}
+                case 'DO_SHOOTING_STAR': {
+                        const star = starCache.get(user.id);
+                        starCache.delete(user.id);
+                        if (star && star.expiry > Date.now()) {
+                                const str = await shootingStarsCommand(interaction.channelId, user, star);
+                                return interactionReply(interaction, str);
+                        }
+                        return interactionReply(interaction, {
+                                content: `${
+                                        star && star.expiry < Date.now()
+                                                ? 'The Crashed Star has expired!'
+                                                : `That Crashed Star was not discovered by ${user.minionName}.`
+                                }`,
+                                ephemeral: true
+                        });
+                }
+                case 'START_TOG': {
+                        return runCommand({
+                                commandName: 'minigames',
+                                args: { tears_of_guthix: { start: {} } },
+                                bypassInhibitors: true,
+                                ...options
+                        });
+                }
+                default: {
+                }
+        }
 }

--- a/src/lib/util/handleTripFinish.ts
+++ b/src/lib/util/handleTripFinish.ts
@@ -4,7 +4,7 @@ import type { AttachmentBuilder, ButtonBuilder, MessageCollector, MessageCreateO
 import { Bank } from 'oldschooljs';
 
 import { Stopwatch } from '@oldschoolgg/toolkit/structures';
-import { sumArr } from 'e';
+import { sumArr, Time } from 'e';
 import { calculateBirdhouseDetails } from '../../mahoji/lib/abstracted_commands/birdhousesCommand';
 import { canRunAutoContract } from '../../mahoji/lib/abstracted_commands/farmingContractCommand';
 import { handleTriggerShootingStar } from '../../mahoji/lib/abstracted_commands/shootingStarsCommand';
@@ -27,8 +27,9 @@ import {
 	makeBirdHouseTripButton,
 	makeNewSlayerTaskButton,
 	makeOpenCasketButton,
-	makeOpenSeedPackButton,
-	makeRepeatTripButton
+       makeOpenSeedPackButton,
+       makeRepeatTripButton,
+       makeTearsOfGuthixButton
 } from './globalInteractions';
 import { sendToChannelID } from './webhook';
 
@@ -222,9 +223,21 @@ export async function handleTripFinish(
 		}
 	}
 
-	if (_components) {
-		components.push(..._components);
-	}
+        if (_components) {
+                components.push(..._components);
+        }
+
+       // Tears of Guthix start button if ready
+       if (!user.bitfield.includes(BitField.DisableTearsOfGuthixButton)) {
+               const stats = await user.fetchStats({ last_tears_of_guthix_timestamp: true });
+               const last = Number(stats.last_tears_of_guthix_timestamp);
+               const ready =
+                       user.QP >= 43 &&
+                       (last === -1 || last === 0 || Date.now() - last >= Time.Day * 7);
+               if (ready) {
+                       components.push(makeTearsOfGuthixButton());
+               }
+       }
 
 	handleTriggerShootingStar(user, data, components);
 

--- a/src/mahoji/commands/config.ts
+++ b/src/mahoji/commands/config.ts
@@ -141,14 +141,38 @@ const toggles: UserConfigToggle[] = [
 		name: 'Disable wilderness high peak time warning',
 		bit: BitField.DisableHighPeakTimeWarning
 	},
-	{
-		name: 'Disable Names on Opens',
-		bit: BitField.DisableOpenableNames
-	},
-	{
-		name: 'Show Detailed Info',
-		bit: BitField.ShowDetailedInfo
-	}
+        {
+                name: 'Disable Names on Opens',
+                bit: BitField.DisableOpenableNames
+        },
+        {
+                name: 'Disable daily reminder DMs',
+                bit: BitField.DisableDailyReminderDMs,
+                canToggle: async user => {
+                        if (user.perkTier() < PerkTier.Two) {
+                                return { result: false, message: patronMsg(PerkTier.Two) };
+                        }
+                        return { result: true };
+                }
+        },
+       {
+               name: 'Disable Tears of Guthix reminder DMs',
+               bit: BitField.DisableTearsOfGuthixReminderDMs,
+               canToggle: async user => {
+                       if (user.perkTier() < PerkTier.Two) {
+                               return { result: false, message: patronMsg(PerkTier.Two) };
+                       }
+                       return { result: true };
+               }
+       },
+       {
+               name: 'Disable Tears of Guthix Trip Button',
+               bit: BitField.DisableTearsOfGuthixButton
+       },
+       {
+               name: 'Show Detailed Info',
+               bit: BitField.ShowDetailedInfo
+       }
 ];
 
 async function handleToggle(user: MUser, name: string, interaction?: ChatInputCommandInteraction) {


### PR DESCRIPTION
## Summary
- Added new bitfields DisableDailyReminderDMs and DisableTearsOfGuthixReminder for users to toggle reminder messages
- Daily reminder queries now skip users who disabled reminders via the new bitfield
- Implemented a new ticker sending Tears of Guthix reminders with a quick-start button for the minigame
- Introduced a global interaction for the Tears of Guthix button and its helper function
- Users with appropriate perk tiers can toggle both reminder types through /config settings
- Rename Tears of Guthix DM toggle bitfield and add new trip button bitfield
- Show Tears of Guthix button in trip finish if ToG is ready
- Expose toggles for the new bitfields via `/config`