### PR TITLE
Add blackjack gamble command

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,6 +108,7 @@ model ClientStorage {
   gp_daily                     BigInt   @default(0)
   gp_luckypick                 BigInt   @default(0)
   gp_slots                     BigInt   @default(0)
+  gp_blackjack                 BigInt   @default(0)
   gp_hotcold                   BigInt   @default(0)
   custom_prices                Json     @default("{}") @db.Json
   nightmare_cost               Json     @default("{}") @db.Json
@@ -739,6 +740,7 @@ model UserStats {
   gp_luckypick BigInt @default(0)
   gp_dice      BigInt @default(0)
   gp_slots     BigInt @default(0)
+  gp_blackjack BigInt @default(0)
   gp_hotcold   BigInt @default(0)
 
   total_gp_traded BigInt @default(0)

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -66,6 +66,7 @@ FROM users;
 			gp_pvm: true,
 			gp_sell: true,
 			gp_slots: true,
+			gp_blackjack: true,
 			gp_tax_balance: true,
 			economyStats_dailiesAmount: true
 		},
@@ -99,7 +100,8 @@ FROM users;
 			gpDaily: currentClientSettings.gp_daily,
 			gpLuckypick: currentClientSettings.gp_luckypick,
 			gpSlots: currentClientSettings.gp_slots,
-			gpHotCold: currentClientSettings.gp_hotcold
+			gpHotCold: currentClientSettings.gp_hotcold,
+			gpBlackjack: currentClientSettings.gp_blackjack
 		}
 	});
 }

--- a/src/mahoji/commands/gamble.ts
+++ b/src/mahoji/commands/gamble.ts
@@ -12,6 +12,7 @@ import { duelCommand } from '../lib/abstracted_commands/duelCommand';
 import { hotColdCommand } from '../lib/abstracted_commands/hotColdCommand';
 import { luckyPickCommand } from '../lib/abstracted_commands/luckyPickCommand';
 import { slotsCommand } from '../lib/abstracted_commands/slotsCommand';
+import { blackjackCommand } from '../lib/abstracted_commands/blackjackCommand';
 import type { OSBMahojiCommand } from '../lib/util';
 
 export const gambleCommand: OSBMahojiCommand = {
@@ -112,24 +113,43 @@ export const gambleCommand: OSBMahojiCommand = {
 		 * Slots
 		 *
 		 */
-		{
-			type: ApplicationCommandOptionType.Subcommand,
-			name: 'slots',
-			description: 'Allows you play slots and risk your GP to win big.',
-			options: [
+                {
+                        type: ApplicationCommandOptionType.Subcommand,
+                        name: 'slots',
+                        description: 'Allows you play slots and risk your GP to win big.',
+                        options: [
 				{
 					type: ApplicationCommandOptionType.String,
 					name: 'amount',
 					description: 'Amount you wish to gamble.',
 					required: false
 				}
-			]
-		},
-		/**
-		 *
-		 * Hot Cold
-		 *
-		 */
+                        ]
+                },
+               {
+                       type: ApplicationCommandOptionType.Subcommand,
+                       name: 'blackjack',
+                       description: 'Play blackjack with 6 decks.',
+                       options: [
+                               {
+                                       type: ApplicationCommandOptionType.String,
+                                       name: 'amount',
+                                       description: 'Amount you wish to gamble.',
+                                       required: true
+                               },
+                               {
+                                       type: ApplicationCommandOptionType.String,
+                                       name: 'sidebet',
+                                       description: 'Optional side bet amount (pair, pays 10:1).',
+                                       required: false
+                               }
+                       ]
+               },
+               /**
+                *
+                * Hot Cold
+                *
+                */
 		{
 			type: ApplicationCommandOptionType.Subcommand,
 			name: 'hot_cold',
@@ -178,10 +198,11 @@ export const gambleCommand: OSBMahojiCommand = {
 		item?: { item?: string; autoconfirm?: boolean };
 		dice?: { amount?: string };
 		duel?: { user: MahojiUserOption; amount?: string };
-		lucky_pick?: { amount: string };
-		slots?: { amount?: string };
-		hot_cold?: { choice?: 'hot' | 'cold'; amount?: string };
-		give_random_item?: { user: MahojiUserOption };
+               lucky_pick?: { amount: string };
+               slots?: { amount?: string };
+               blackjack?: { amount: string; sidebet?: string };
+               hot_cold?: { choice?: 'hot' | 'cold'; amount?: string };
+               give_random_item?: { user: MahojiUserOption };
 	}>) => {
 		const user = await mUserFetch(userID);
 
@@ -217,13 +238,17 @@ export const gambleCommand: OSBMahojiCommand = {
 			return luckyPickCommand(user, options.lucky_pick.amount, interaction);
 		}
 
-		if (options.slots) {
-			return slotsCommand(interaction, user, options.slots.amount);
-		}
+               if (options.slots) {
+                       return slotsCommand(interaction, user, options.slots.amount);
+               }
 
-		if (options.hot_cold) {
-			return hotColdCommand(interaction, user, options.hot_cold.choice, options.hot_cold.amount);
-		}
+               if (options.blackjack) {
+                       return blackjackCommand(interaction, user, options.blackjack.amount, options.blackjack.sidebet);
+               }
+
+               if (options.hot_cold) {
+                       return hotColdCommand(interaction, user, options.hot_cold.choice, options.hot_cold.amount);
+               }
 
 		if (options.give_random_item) {
 			const senderUser = user;

--- a/src/mahoji/lib/abstracted_commands/blackjackCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/blackjackCommand.ts
@@ -1,0 +1,236 @@
+import { awaitMessageComponentInteraction, channelIsSendable } from '@oldschoolgg/toolkit/util';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, type ChatInputCommandInteraction } from 'discord.js';
+import { noOp, shuffleArr } from 'e';
+import { Bank, Util } from 'oldschooljs';
+
+import { deferInteraction } from '../../../lib/util/interactionReply';
+import { mahojiParseNumber, updateClientGPTrackSetting, updateGPTrackSetting } from '../../mahojiSettings';
+
+const suits = ['♠', '♥', '♦', '♣'];
+const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+
+function createDeck() {
+       const deck: string[] = [];
+       for (let i = 0; i < 6; i++) {
+               for (const r of ranks) {
+                       for (const s of suits) deck.push(`${r}${s}`);
+               }
+       }
+       return shuffleArr(deck);
+}
+
+function draw(deck: string[]) {
+       return deck.pop()!;
+}
+
+function handValue(hand: string[]) {
+        let value = 0;
+        let aces = 0;
+        for (const c of hand) {
+               const rank = c.slice(0, -1);
+               if (rank === 'A') {
+                       value += 11;
+                       aces++;
+               } else if (['J', 'Q', 'K'].includes(rank)) {
+                       value += 10;
+               } else {
+                       value += Number(rank);
+               }
+        }
+       while (value > 21 && aces > 0) {
+               value -= 10;
+               aces--;
+       }
+       return value;
+}
+
+function formatHands(
+       user: MUser,
+       hands: string[][],
+       dealer: string[],
+       hideDealer: boolean,
+       active = 0
+) {
+       const dealerDisplay = hideDealer ? `${dealer[0]}, ?` : dealer.join(', ');
+       const dealerValue = hideDealer ? handValue([dealer[0]]) : handValue(dealer);
+       let res = `Dealer: ${dealerDisplay} (${dealerValue})`;
+       if (hands.length === 1) {
+               const [hand] = hands;
+               res += `\n${user.badgedUsername}: ${hand.join(', ')} (${handValue(hand)})`;
+       } else {
+               for (let i = 0; i < hands.length; i++) {
+                       const mark = i === active ? '*' : '';
+                       res += `\nHand ${i + 1}${mark}: ${hands[i].join(', ')} (${handValue(hands[i])})`;
+               }
+       }
+       return res;
+}
+
+export async function blackjackCommand(
+       interaction: ChatInputCommandInteraction,
+       user: MUser,
+       _amount: string | undefined,
+       _sidebet?: string
+) {
+       await deferInteraction(interaction);
+       if (interaction.user.bot) return 'Bots cannot gamble.';
+       const amount = mahojiParseNumber({ input: _amount, min: 1, max: 500_000_000 });
+       if (!amount) return 'You must specify an amount between 1 and 500m.';
+       const sideBet = _sidebet ? mahojiParseNumber({ input: _sidebet, min: 1, max: amount }) : null;
+       if (_sidebet && !sideBet) return 'Invalid sidebet amount.';
+       if (user.isIronman) return "Ironmen can't gamble.";
+       if (amount < 100_000) return 'Minimum bet is 100k.';
+       let totalBet = amount + (sideBet ?? 0);
+       if (user.GP < totalBet) return "You don't have enough GP.";
+
+	const channel = globalClient.channels.cache.get(interaction.channelId);
+	if (!channelIsSendable(channel)) return 'Invalid channel.';
+
+       await user.removeItemsFromBank(new Bank().add('Coins', totalBet));
+       const deck = createDeck();
+       const player = [draw(deck), draw(deck)];
+       const dealer = [draw(deck), draw(deck)];
+
+       const hands: string[][] = [player];
+       const bets: number[] = [amount];
+       const doubled: boolean[] = [false];
+       let activeHand = 0;
+
+       let canSplit = player[0].slice(0, -1) === player[1].slice(0, -1) && user.GP >= amount;
+
+       const componentsRow = (handIndex: number, allowSplit: boolean) => [
+               new ActionRowBuilder<ButtonBuilder>().addComponents([
+                       new ButtonBuilder().setCustomId('HIT').setLabel('Hit').setStyle(ButtonStyle.Primary),
+                       new ButtonBuilder().setCustomId('STAND').setLabel('Stand').setStyle(ButtonStyle.Secondary),
+                       ...(!doubled[handIndex]
+                               ? [new ButtonBuilder().setCustomId('DOUBLE').setLabel('Double Down').setStyle(ButtonStyle.Success)]
+                               : []),
+                       ...(allowSplit
+                               ? [new ButtonBuilder().setCustomId('SPLIT').setLabel('Split').setStyle(ButtonStyle.Danger)]
+                               : [])
+               ])
+       ];
+
+       const message = await channel.send({
+               content: formatHands(user, hands, dealer, true, activeHand),
+               components: componentsRow(activeHand, canSplit)
+       });
+
+       while (activeHand < hands.length) {
+               let playerValue = handValue(hands[activeHand]);
+               while (playerValue < 21) {
+                       const selection = await awaitMessageComponentInteraction({
+                               message,
+                               filter: i => i.user.id === user.id,
+                               time: 15000
+                       }).catch(() => null);
+                       if (!selection) {
+                               await message.edit({ components: [] }).catch(noOp);
+                               await user.addItemsToBank({ items: new Bank().add('Coins', totalBet), collectionLog: false });
+                               return 'Blackjack timed out, bet refunded.';
+                       }
+
+                       if (selection.customId === 'HIT') {
+                               hands[activeHand].push(draw(deck));
+                               playerValue = handValue(hands[activeHand]);
+                               await selection.deferUpdate().catch(noOp);
+                               await message.edit({
+                                       content: formatHands(user, hands, dealer, true, activeHand),
+                                       components: playerValue >= 21 ? [] : componentsRow(activeHand, false)
+                               });
+                               if (playerValue >= 21) break;
+                               continue;
+                       }
+
+                       if (selection.customId === 'DOUBLE') {
+                               if (user.GP < amount) {
+                                       await selection.reply({ ephemeral: true, content: "You don't have enough GP to double down." }).catch(noOp);
+                                       continue;
+                               }
+                               await selection.deferUpdate().catch(noOp);
+                               await user.removeItemsFromBank(new Bank().add('Coins', amount));
+                               totalBet += amount;
+                               bets[activeHand] += amount;
+                               doubled[activeHand] = true;
+                               hands[activeHand].push(draw(deck));
+                               playerValue = handValue(hands[activeHand]);
+                               await message.edit({ content: formatHands(user, hands, dealer, true, activeHand), components: [] });
+                               break;
+                       }
+
+                       if (selection.customId === 'SPLIT' && canSplit && activeHand === 0) {
+                               if (user.GP < amount) {
+                                       await selection.reply({ ephemeral: true, content: "You don't have enough GP to split." }).catch(noOp);
+                                       continue;
+                               }
+                               await selection.deferUpdate().catch(noOp);
+                               await user.removeItemsFromBank(new Bank().add('Coins', amount));
+                               totalBet += amount;
+                               hands[0] = [player[0], draw(deck)];
+                               hands.push([player[1], draw(deck)]);
+                               bets.push(amount);
+                               doubled.push(false);
+                               canSplit = false;
+                               await message.edit({ content: formatHands(user, hands, dealer, true, activeHand), components: componentsRow(activeHand, false) });
+                               playerValue = handValue(hands[activeHand]);
+                               continue;
+                       }
+
+                       if (selection.customId === 'STAND') {
+                               await selection.deferUpdate().catch(noOp);
+                               break;
+                       }
+               }
+
+               activeHand++;
+               if (activeHand < hands.length) {
+                       await message.edit({ content: formatHands(user, hands, dealer, true, activeHand), components: componentsRow(activeHand, false) });
+               }
+       }
+
+       let dealerValue = handValue(dealer);
+       while (dealerValue < 17) {
+               dealer.push(draw(deck));
+               dealerValue = handValue(dealer);
+       }
+
+       await message.edit({ content: formatHands(user, hands, dealer, false), components: [] }).catch(noOp);
+
+       let payout = 0;
+       const resultParts: string[] = [];
+       for (let i = 0; i < hands.length; i++) {
+               const value = handValue(hands[i]);
+               if (value > 21) {
+                       resultParts.push(`Hand ${i + 1}: bust.`);
+                       continue;
+               }
+               if (dealerValue > 21 || value > dealerValue) {
+                       const won = bets[i] * 2;
+                       payout += won;
+                       resultParts.push(`Hand ${i + 1}: won ${Util.toKMB(won)}.`);
+               } else if (value === dealerValue) {
+                       payout += bets[i];
+                       resultParts.push(`Hand ${i + 1}: push.`);
+               } else {
+                       resultParts.push(`Hand ${i + 1}: lost.`);
+               }
+       }
+
+       let sideBetPayout = 0;
+       if (sideBet && player[0].slice(0, -1) === player[1].slice(0, -1)) {
+               sideBetPayout = sideBet * 10;
+       }
+
+       const totalPayout = payout + sideBetPayout;
+       if (totalPayout > 0) {
+               await user.addItemsToBank({ items: new Bank().add('Coins', totalPayout), collectionLog: false });
+       }
+       await updateClientGPTrackSetting('gp_blackjack', totalPayout - totalBet);
+       await updateGPTrackSetting('gp_blackjack', totalPayout - totalBet, user);
+
+       if (sideBet) {
+               resultParts.push(sideBetPayout > 0 ? `Side bet won ${Util.toKMB(sideBetPayout)}.` : 'Side bet lost.');
+       }
+
+       return { content: resultParts.join('\n') };
+}

--- a/src/mahoji/mahojiSettings.ts
+++ b/src/mahoji/mahojiSettings.ts
@@ -147,6 +147,7 @@ export async function updateClientGPTrackSetting(
 		| 'gp_pickpocket'
 		| 'gp_alch'
 		| 'gp_slots'
+		| 'gp_blackjack'
 		| 'gp_dice'
 		| 'gp_open'
 		| 'gp_daily'
@@ -170,7 +171,7 @@ export async function updateClientGPTrackSetting(
 	});
 }
 export async function updateGPTrackSetting(
-	setting: 'gp_dice' | 'gp_luckypick' | 'gp_slots',
+	setting: 'gp_dice' | 'gp_luckypick' | 'gp_slots' | 'gp_blackjack',
 	amount: number,
 	user: MUser
 ) {


### PR DESCRIPTION
## Summary
- add blackjack gamble functionality with hit and stand buttons
- track gp_blackjack stats
- support optional side bets and doubling down in blackjack
- allow splitting pairs into two hands

## Testing
- `npx --yes biome check src/mahoji/lib/abstracted_commands/blackjackCommand.ts src/mahoji/commands/gamble.ts`
- `pnpm test` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c14ea46408326846bdb050887caae