### PR TITLE
Improve blackjack logic

### DIFF
--- a/tests/integration/commands/blackjack.test.ts
+++ b/tests/integration/commands/blackjack.test.ts
@@ -1,8 +1,8 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { Bank } from 'oldschooljs';
 
 import { blackjackCommand } from '../../../src/mahoji/lib/abstracted_commands/blackjackCommand';
-import { createTestUser } from '../util';
+import { createTestUser, type TestUser } from '../util';
 
 // Mock deck shuffling and user interaction
 let deck: string[] = [];
@@ -30,8 +30,12 @@ const fakeInteraction = {
         channel: { send: vi.fn().mockResolvedValue(fakeMessage) }
 } as any;
 
-describe('Blackjack Split', async () => {
-        const user = await createTestUser();
+describe('Blackjack Split', () => {
+        let user: TestUser;
+
+        beforeAll(async () => {
+                user = await createTestUser();
+        });
 
         beforeEach(async () => {
                 await user.reset();


### PR DESCRIPTION
## Summary
- track increasing bets during splits and doubles
- hide Double button when out of GP
- warn players who try to double without enough GP
- optimize handValue loop
- fix integration test structure

## Testing
- `pnpm test` *(fails: Failed Suites 27)*
- `pnpm test:types` *(fails: tsc exited with code 2)*

------
https://chatgpt.com/codex/tasks/task_e_686d8382d60c8326be4842c7c71a2e04