### PR TITLE
Add mocktrip test command

### DIFF
--- a/docs/src/content/docs/getting-started/developing.md
+++ b/docs/src/content/docs/getting-started/developing.md
@@ -26,6 +26,8 @@ lastUpdated: 2024-10-01T03:41:00.552Z
 
 `pnpm monorepo:test`: Run this if you want to test either monorepo (oldschooljs or toolkit).
 
+`/mocktrip command:<your trip>`: Quickly simulate a trip with a fully maxed mock account. Useful for checking XP rates and loot; it does **not** give real progression.
+
 ### Spritesheet
 
 The spritesheet is a big image file containing most icons the bot uses for items, not all items are in it, if the bot need any that aren't in it, it will download them on demand.

--- a/src/mahoji/commands/allCommands.ts
+++ b/src/mahoji/commands/allCommands.ts
@@ -80,6 +80,7 @@ import { tksCommand } from './tokkulshop';
 import { toolsCommand } from './tools';
 import { tradeCommand } from './trade';
 import { triviaCommand } from './trivia';
+import { mockTripCommand } from './mocktrip';
 import { mahojiUseCommand } from './use';
 import { wikiCommand } from './wiki';
 import { xpCommand } from './xp';
@@ -129,8 +130,9 @@ export const allCommands: OSBMahojiCommand[] = [
 	massCommand,
 	minigamesCommand,
 	minionCommand,
-	simulateCommand,
-	sellCommand,
+        simulateCommand,
+        mockTripCommand,
+        sellCommand,
 	sacrificeCommand,
 	rollCommand,
 	runecraftCommand,

--- a/src/mahoji/commands/mocktrip.ts
+++ b/src/mahoji/commands/mocktrip.ts
@@ -1,0 +1,81 @@
+import { type CommandRunOptions, stringMatches } from '@oldschoolgg/toolkit/util';
+import { ApplicationCommandOptionType } from 'discord.js';
+import { Time } from 'e';
+import { Bank, convertLVLtoXP } from 'oldschooljs';
+
+import { TOBMaxMageGear, TOBMaxMeleeGear, TOBMaxRangeGear } from '../../lib/data/tob';
+import Mining from '../../lib/skilling/skills/mining';
+import { SkillsArray } from '../../lib/skilling/types';
+import { Gear } from '../../lib/structures/Gear';
+import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
+import { determineMiningTrip } from './mine';
+import { determineMiningResult } from '../../tasks/minions/miningActivity';
+import { mockMUser } from '../../tests/unit/userutil';
+import type { OSBMahojiCommand } from '../lib/util';
+
+export const mockTripCommand: OSBMahojiCommand = {
+    name: 'mocktrip',
+    description: 'Instantly simulate a trip on a maxed mock account.',
+    options: [
+        {
+            type: ApplicationCommandOptionType.String,
+            name: 'command',
+            description: 'Trip command text, e.g. "mine granite"',
+            required: true
+        }
+    ],
+    run: async ({ options }: CommandRunOptions<{ command: string }>) => {
+        const input = options.command.split(/\s+/);
+        const action = input.shift()?.toLowerCase();
+        if (action !== 'mine') {
+            return 'Only mining is supported.';
+        }
+        const oreName = input.shift();
+        if (!oreName) return 'No ore specified.';
+        const qty = input.length > 0 ? Number(input.shift()) : undefined;
+        const ore = Mining.Ores.find(
+            o =>
+                stringMatches(o.name, oreName) ||
+                stringMatches(o.id, oreName) ||
+                o.aliases?.some(a => stringMatches(a, oreName))
+        );
+        if (!ore) return 'Invalid ore.';
+
+        const maxXP = convertLVLtoXP(99);
+        const skills: any = {};
+        for (const skill of SkillsArray) skills[`skills_${skill}`] = maxXP;
+
+        const bank = new Bank().add('Crystal pickaxe');
+        for (const gear of [new Gear(TOBMaxMeleeGear), new Gear(TOBMaxRangeGear), new Gear(TOBMaxMageGear)]) {
+            bank.add(gear.allItemsBank());
+        }
+
+        const mock = mockMUser({ ...skills, bank });
+        mock.user.gear_melee = TOBMaxMeleeGear.raw() as any;
+        mock.user.gear_range = TOBMaxRangeGear.raw() as any;
+        mock.user.gear_mage = TOBMaxMageGear.raw() as any;
+        mock.updateProperties();
+
+        const trip = determineMiningTrip({
+            gearBank: mock.gearBank,
+            ore,
+            maxTripLength: calcMaxTripLength(mock, 'Mining'),
+            isPowermining: false,
+            quantityInput: qty,
+            hasKaramjaMedium: false,
+            randomVariationEnabled: false
+        });
+        const result = determineMiningResult({
+            ore,
+            quantity: trip.quantity,
+            gearBank: mock.gearBank,
+            duration: trip.duration,
+            isPowermining: false,
+            hasFinishedCOTS: true
+        });
+        const xpHr = (
+            (result.updateBank.xpBank.totalXP() / (trip.duration / Time.Minute)) * 60
+        ).toFixed(1);
+        return `Mined ${trip.quantity} ${ore.name} for ${result.updateBank.xpBank.toString()} (${xpHr} xp/hr) and ${result.updateBank.itemLootBank}.`;
+    }
+};

--- a/src/mahoji/commands/testpotato.ts
+++ b/src/mahoji/commands/testpotato.ts
@@ -26,6 +26,10 @@ import { slayerMasters } from '../../lib/slayer/slayerMasters';
 import { getUsersCurrentSlayerInfo } from '../../lib/slayer/slayerUtil';
 import { allSlayerMonsters } from '../../lib/slayer/tasks';
 import { Gear } from '../../lib/structures/Gear';
+import { calcMaxTripLength } from '../../lib/util/calcMaxTripLength';
+import { determineMiningTrip } from './mine';
+import { determineMiningResult } from '../../tasks/minions/miningActivity';
+import { SkillsArray } from '../../lib/skilling/types';
 import type { FarmingPatchName } from '../../lib/util/farmingHelpers';
 import { farmingPatchNames, getFarmingKeyFromName, userGrowingProgressStr } from '../../lib/util/farmingHelpers';
 import getOSItem from '../../lib/util/getOSItem';
@@ -36,6 +40,7 @@ import { gearViewCommand } from '../lib/abstracted_commands/gearCommands';
 import { getPOH } from '../lib/abstracted_commands/pohCommand';
 import { allUsableItems } from '../lib/abstracted_commands/useCommand';
 import { BingoManager } from '../lib/bingo/BingoManager';
+import { mockMUser } from '../../tests/unit/userutil';
 import type { OSBMahojiCommand } from '../lib/util';
 import { userStatsUpdate } from '../mahojiSettings';
 import { fetchBingosThatUserIsInvolvedIn } from './bingo';
@@ -376,16 +381,16 @@ export const testPotatoCommand: OSBMahojiCommand | null = globalConfig.isProduct
 						}
 					]
 				},
-				{
-					type: ApplicationCommandOptionType.Subcommand,
-					name: 'max',
-					description: 'Set all your stats to the maximum level, and get max QP.'
-				},
-				{
-					type: ApplicationCommandOptionType.Subcommand,
-					name: 'patron',
-					description: 'Set your patron perk level.',
-					options: [
+                                {
+                                        type: ApplicationCommandOptionType.Subcommand,
+                                        name: 'max',
+                                        description: 'Set all your stats to the maximum level, and get max QP.'
+                                },
+                                {
+                                        type: ApplicationCommandOptionType.Subcommand,
+                                        name: 'patron',
+                                        description: 'Set your patron perk level.',
+                                        options: [
 						{
 							type: ApplicationCommandOptionType.String,
 							name: 'tier',
@@ -585,10 +590,10 @@ export const testPotatoCommand: OSBMahojiCommand | null = globalConfig.isProduct
 				wipe?: { thing: (typeof thingsToWipe)[number] };
 				set?: { qp?: number; all_ca_tasks?: boolean };
 				get_code?: {};
-				bingo_tools?: { start_bingo: string };
-				setslayertask?: { master: string; monster: string; quantity: number };
-				events?: {};
-			}>) => {
+                                bingo_tools?: { start_bingo: string };
+                                setslayertask?: { master: string; monster: string; quantity: number };
+                               events?: {};
+                       }>) => {
 				if (globalConfig.isProduction) {
 					logError('Test command ran in production', { userID: userID.toString() });
 					return 'This will never happen...';
@@ -875,7 +880,7 @@ Warning: Visiting a test dashboard may let developers see your IP address. Attem
 				if (options.setxp) {
 					return setXP(user, options.setxp.skill, options.setxp.xp);
 				}
-				if (options.spawn) {
+                               if (options.spawn) {
 					const { preset, collectionlog, item, items } = options.spawn;
 					const bankToGive = new Bank();
 					if (preset) {
@@ -903,9 +908,10 @@ Warning: Visiting a test dashboard may let developers see your IP address. Attem
 						}
 					}
 
-					await user.addItemsToBank({ items: bankToGive, collectionLog: Boolean(collectionlog) });
-					return `Spawned: ${bankToGive.toString().slice(0, 500)}.`;
-				}
+                                       await user.addItemsToBank({ items: bankToGive, collectionLog: Boolean(collectionlog) });
+                                       return `Spawned: ${bankToGive.toString().slice(0, 500)}.`;
+                               }
+
 
 				if (options.setmonsterkc) {
 					const monster = effectiveMonsters.find(m =>

--- a/tests/unit/mockuser.test.ts
+++ b/tests/unit/mockuser.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest';
+
+import { mockTripCommand } from '../../src/mahoji/commands/mocktrip';
+
+const dummyOptions = { command: 'mine copper 1' } as any;
+
+describe('mocktrip subcommand', () => {
+    test('returns result and does not modify user', async () => {
+        const res = await mockTripCommand.run({ options: dummyOptions } as any);
+        expect(typeof res).toBe('string');
+    });
+});
+


### PR DESCRIPTION
## Summary
- add a standalone `mocktrip` command for instant trip simulations
- remove mocktrip subcommand from `testpotato`
- document new command in developer guide
- update unit test for mocktrip

## Testing
- `pnpm dev` *(fails: Command "concurrently" not found)*
- `pnpm lint` *(fails: tsx not found)*
- `pnpm test` *(fails: concurrently not found)*