### PR TITLE
Add mockuser command

### DIFF
--- a/src/lib/mock/createMockUser.ts
+++ b/src/lib/mock/createMockUser.ts
@@ -1,0 +1,43 @@
+import { convertLVLtoXP } from 'oldschooljs';
+import { xp_gains_skill_enum } from '@prisma/client';
+import type { MUser } from '../MUser';
+import { MAX_QP } from '../minions/data/quests';
+import { GearBank } from '../structures/GearBank';
+import { Bank } from 'oldschooljs';
+import { SkillsEnum } from '../skilling/types';
+
+export function createMockUser(user: MUser): MUser {
+  const maxLevels: Record<xp_gains_skill_enum, number> = {} as any;
+  const maxXP: Record<xp_gains_skill_enum, number> = {} as any;
+  for (const skill of Object.values(xp_gains_skill_enum)) {
+    maxLevels[skill] = 99;
+    maxXP[skill] = convertLVLtoXP(99);
+  }
+  const fake = Object.create(user);
+  fake.skillLevel = () => 99;
+  fake.skillsAsLevels = maxLevels as any;
+  fake.skillsAsXP = maxXP as any;
+  fake.owns = () => true;
+  fake.hasEquippedOrInBank = () => true;
+  fake.hasEquipped = () => true;
+  fake.hasSkillReqs = () => true;
+  fake.GP = 1_000_000_000;
+  fake.QP = MAX_QP;
+  fake.minionIsBusy = false;
+  fake.update = async () => ({ newUser: user.user });
+  fake.addItemsToBank = async () => undefined;
+  fake.removeItemsFromBank = async () => undefined;
+  fake.addXP = () => '';
+  Object.defineProperty(fake, 'gearBank', {
+    get() {
+      return new GearBank({
+        gear: user.gear,
+        bank: new Bank(),
+        skillsAsLevels: maxLevels as any,
+        chargeBank: user.ownedChargeBank(),
+        skillsAsXP: maxXP as any
+      });
+    }
+  });
+  return fake;
+}

--- a/src/lib/util/addSubTaskToActivityTask.ts
+++ b/src/lib/util/addSubTaskToActivityTask.ts
@@ -7,8 +7,11 @@ import { logError } from './logError';
 import { getActivityOfUser } from './minionIsBusy';
 
 export default async function addSubTaskToActivityTask<T extends ActivityTaskData>(
-	taskToAdd: Omit<T, 'finishDate' | 'id'>
+        taskToAdd: Omit<T, 'finishDate' | 'id'>
 ) {
+       if ((global as any).__mockMode) {
+               return null;
+       }
 	const usersTask = getActivityOfUser(taskToAdd.userID);
 	if (usersTask) {
 		throw new UserError(

--- a/src/mahoji/commands/allCommands.ts
+++ b/src/mahoji/commands/allCommands.ts
@@ -83,6 +83,7 @@ import { triviaCommand } from './trivia';
 import { mahojiUseCommand } from './use';
 import { wikiCommand } from './wiki';
 import { xpCommand } from './xp';
+import { mockuserCommand } from './mockuser';
 
 export const allCommands: OSBMahojiCommand[] = [
 	adminCommand,
@@ -164,9 +165,10 @@ export const allCommands: OSBMahojiCommand[] = [
 	geCommand,
 	rpCommand,
 	collectionLogCommand,
-	gearPresetsCommand,
-	statsCommand,
-	xpCommand
+        gearPresetsCommand,
+        statsCommand,
+        xpCommand,
+        mockuserCommand
 ];
 
 if (!globalConfig.isProduction && testPotatoCommand) {

--- a/src/mahoji/commands/mockuser.ts
+++ b/src/mahoji/commands/mockuser.ts
@@ -1,0 +1,56 @@
+import { ApplicationCommandOptionType } from 'discord.js';
+import type { CommandRunOptions } from '@oldschoolgg/toolkit/util';
+
+import { createMockUser } from '../../lib/mock/createMockUser';
+import { mUserFetch } from '../../lib/MUser';
+import type { OSBMahojiCommand } from '../lib/util';
+
+function parseArgs(input: string): {command: string; args: Record<string, any>} {
+  const parts = input.split(/\s+/);
+  const command = parts.shift()?.toLowerCase() ?? '';
+  const args: Record<string, any> = {};
+  let i = 0;
+  for (const part of parts) {
+    if (part.includes(':')) {
+      const [key, val] = part.split(':');
+      let v: any = val;
+      if (val === 'true') v = true;
+      else if (val === 'false') v = false;
+      else if (!isNaN(Number(val))) v = Number(val);
+      args[key] = v;
+    } else if (i === 0) {
+      args.name = part;
+      i++;
+    }
+  }
+  return { command, args };
+}
+
+export const mockuserCommand: OSBMahojiCommand = {
+  name: 'mockuser',
+  description: 'Simulate a minion trip using a mock maxed user.',
+  options: [
+    {
+      type: ApplicationCommandOptionType.String,
+      name: 'input',
+      description: 'Command and args, e.g. "mine granite quantity:1"',
+      required: true
+    }
+  ],
+  run: async ({ options, userID, channelID }: CommandRunOptions<{ input: string }>) => {
+    const { command, args } = parseArgs(options.input);
+    const cmd = Array.from(globalClient.mahojiClient.commands.values()).find(c => c.name === command);
+    if (!cmd) return `Unknown command: ${command}`;
+    const realUser = await mUserFetch(userID);
+    const mock = createMockUser(realUser);
+    (global as any).__mockMode = true;
+    try {
+      const res: any = await cmd.run({ options: args, userID, channelID });
+      if (typeof res === 'string') return `MOCK TRIP: ${res}`;
+      if (res && typeof res.content === 'string') res.content = `MOCK TRIP: ${res.content}`;
+      return res;
+    } finally {
+      (global as any).__mockMode = false;
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add helper to create a mock user with max stats
- add `/mockuser` command for simulating trips
- skip activity queue when running in mock mode
- register the new command

## Testing
- `pnpm test` *(fails: Failed to resolve entry for package "oldschooljs" and other setup issues)*