### PR TITLE
Add tame KC leaderboard option

### DIFF
--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -4,15 +4,32 @@ import { leaderboardCommand } from '../../src/mahoji/commands/leaderboard';
 import { kcGains } from '../../src/mahoji/commands/tools';
 import { createTestUser } from './util';
 
-describe.skip('Leaderboard', async () => {
-	test('KC Leaderboard', async () => {
-		const user = await createTestUser();
-		await user.runCommand(leaderboardCommand, {
-			kc: {
-				monster: 'man'
-			}
-		});
-	});
+describe('Leaderboard', async () => {
+        test('KC Leaderboard', async () => {
+                const user = await createTestUser();
+                await user.runCommand(leaderboardCommand, {
+                        kc: {
+                                monster: 'man'
+                        }
+                });
+        });
+
+       test('KC Leaderboard Tame', async () => {
+               const user = await createTestUser();
+               await user.runCommand(leaderboardCommand, {
+                       kc: {
+                               monster: 'Zulrah',
+                               tame: true
+                       }
+               });
+       });
+
+       test('Tames Hatched Leaderboard', async () => {
+               const user = await createTestUser();
+               await user.runCommand(leaderboardCommand, {
+                       tames_hatched: {}
+               });
+       });
 
 	test('kcGains Leaderboard', async () => {
 		for (const bool of [true, false]) {


### PR DESCRIPTION
## Summary
- support `/lb kc tame:true` to show kill counts from tames
- add `/lb tames_hatched` leaderboard for eggs hatched
- document revert (no doc change from previous)
- update integration tests for new option

## Testing
- `pnpm test:unit` *(fails: vitest not found)*
- `npx vitest run --config vitest.integration.config.mts tests/integration/leaderboard.test.ts` *(prompts to install vitest)*