### PR TITLE
fix: restore dark altar rune arg

### DIFF
--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -277,7 +277,7 @@ const tripHandlers = {
 	[activity_type_enum.DarkAltar]: {
 		commandName: 'runecraft',
 		args: (data: DarkAltarOptions) => ({
-			rune: `${darkAltarRunes[data.rune].item.name} (zeah)`,
+			rune: `${data.rune} rune (zeah)`,
 			extracts: data.useExtracts
 		})
 	},


### PR DESCRIPTION
## Summary
- restore dark altar rune args to use raw rune name

## Testing
- `pnpm test:lint`
- `pnpm test:unit` (fails: Failed to resolve entry for package "oldschooljs")
- `pnpm test:types` (fails: tsc --noEmit exited with code 2)


------
https://chatgpt.com/codex/tasks/task_e_68b17800129c83269d32c345c9ec9c62