### PR TITLE
fix leaderboard integration test syntax

### DIFF
--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -1,31 +1,32 @@
 import { describe, test } from 'vitest';
 
-import { kcGains } from '../../src/mahoji/commands/tools';
+import { leaderboardCommand } from '../../src/mahoji/commands/leaderboard';
 import { createTestUser } from './util';
 
 describe('Leaderboard', async () => {
-        test('KC Leaderboard', async () => {
-                const user = await createTestUser();
-                await user.runCommand(leaderboardCommand, {
-                        kc: {
-                                monster: 'man'
-                        }
-                });
-        });
+	test('KC Leaderboard', async () => {
+		const user = await createTestUser();
+		await user.runCommand(leaderboardCommand, {
+			kc: {
+				monster: 'man'
+			}
+		});
+	});
 
-       test('KC Leaderboard Tame', async () => {
-               const user = await createTestUser();
-               await user.runCommand(leaderboardCommand, {
-                       kc: {
-                               monster: 'Zulrah',
-                               tame: true
-                       }
-               });
-       });
+	test('KC Leaderboard Tame', async () => {
+		const user = await createTestUser();
+		await user.runCommand(leaderboardCommand, {
+			kc: {
+				monster: 'Zulrah',
+				tame: true
+			}
+		});
+	});
 
-       test('Tames Hatched Leaderboard', async () => {
-               const user = await createTestUser();
-               await user.runCommand(leaderboardCommand, {
-                       tames_hatched: {}
-               });
-       });
+	test('Tames Hatched Leaderboard', async () => {
+		const user = await createTestUser();
+		await user.runCommand(leaderboardCommand, {
+			tames_hatched: {}
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- import leaderboardCommand and close describe block in leaderboard integration test

## Testing
- `pnpm lint`
- `pnpm vitest run tests/integration/leaderboard.test.ts --config vitest.integration.config.mts` *(fails: Cannot read properties of undefined (reading 'baby'))*
