### PR TITLE
feat: add zero-time fletching at zmi

### DIFF
--- a/docs/src/content/docs/osb/Skills/fletching.md
+++ b/docs/src/content/docs/osb/Skills/fletching.md
@@ -28,3 +28,13 @@ Broad arrows, Broad bolts, Amethyst broad bolts, all types of darts, arrows,
 bolts, tipped bolts and javelins. The required items are removed from your bank
 at the start of the trip and your minion will fletch as many as possible while
 running the Sepulchre.
+
+### Fletching at the Ourania Altar
+
+You can also fletch the same "zero-time" items while runecrafting at the
+Ourania Altar. Use the `fletch:` option when starting a trip:
+
+- `[[/runecraft rune\:ourania altar fletch\:Rune dart]]`
+
+Doing so consumes three inventory spaces for supplies and lets your minion
+fletch up to **25,000** items per hour without extending the trip.

--- a/docs/src/content/docs/osb/Skills/runecrafting.md
+++ b/docs/src/content/docs/osb/Skills/runecrafting.md
@@ -8,6 +8,10 @@ Runecrafting can also be trained at the [Guardians of the Rift](/osb/activities/
 When equipped in the skilling setup, the **Raiments of the eye** outfit grants up to **60%** extra runes during the minigame and while regular runecrafting.
 An **Abyssal lantern** can be purchased with Abyssal pearls to further boost barrier repairs and mined fragments based on your Firemaking level.
 
+While crafting at the Ourania Altar you can use the `fletch:` option to fletch
+zero-time items at no additional time cost. This uses three inventory spaces and
+allows up to **25,000** fletched items per hour.
+
 ## Boosts
 
 There are several boosts available which apply to all runes except blood and soul runes. You can view the boosts for blood and soul runes on the [Dark Altar page](https://wiki.oldschool.gg/skills/runecrafting/dark-altar). The true blood altar uses the same boosts as regular runecrafting.

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -108,10 +108,14 @@ export interface DarkAltarOptions extends ActivityTaskOptions {
 }
 
 export interface OuraniaAltarOptions extends ActivityTaskOptions {
-	type: 'OuraniaAltar';
-	quantity: number;
-	stamina: boolean;
-	daeyalt: boolean;
+        type: 'OuraniaAltar';
+        quantity: number;
+        stamina: boolean;
+       daeyalt: boolean;
+       fletch?: {
+               id: number;
+               qty: number;
+       };
 }
 
 export interface AgilityActivityTaskOptions extends ActivityTaskOptions {

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -68,11 +68,12 @@ import type {
 	OfferingActivityTaskOptions,
 	PickpocketActivityTaskOptions,
 	PlunderActivityTaskOptions,
-	RaidsOptions,
-	RunecraftActivityTaskOptions,
-	SawmillActivityTaskOptions,
-	ScatteringActivityTaskOptions,
-	SepulchreActivityTaskOptions,
+        RaidsOptions,
+        RunecraftActivityTaskOptions,
+       OuraniaAltarOptions,
+        SawmillActivityTaskOptions,
+        ScatteringActivityTaskOptions,
+        SepulchreActivityTaskOptions,
 	ShadesOfMortonOptions,
 	SmeltingActivityTaskOptions,
 	SmithingActivityTaskOptions,
@@ -571,9 +572,14 @@ export function minionStatus(user: MUser) {
 				data.useExtracts ? ' with extracts' : ''
 			}. ${formattedDuration}`;
 		}
-		case 'OuraniaAltar': {
-			return `${name} is currently runecrafting at the Ourania Altar. ${formattedDuration}`;
-		}
+               case 'OuraniaAltar': {
+                       const data = currentTask as OuraniaAltarOptions;
+                       const fletchable = data.fletch ? zeroTimeFletchables.find(i => i.id === data.fletch!.id) : null;
+                       const fletchingPart = fletchable
+                               ? `They are also fletching ${data.fletch!.qty}x ${fletchable.name}. `
+                               : '';
+                       return `${name} is currently runecrafting at the Ourania Altar. ${fletchingPart}${formattedDuration}`;
+               }
 
 		case 'Trekking': {
 			return `${name} is currently Temple Trekking. ${formattedDuration}`;

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -297,15 +297,16 @@ const tripHandlers = {
 			extracts: data.useExtracts
 		})
 	},
-	[activity_type_enum.OuraniaAltar]: {
-		commandName: 'runecraft',
-		args: (data: OuraniaAltarOptions) => ({
-			rune: 'ourania altar',
-			usestams: data.stamina,
-			daeyalt_essence: data.daeyalt,
-			quantity: data.quantity
-		})
-	},
+       [activity_type_enum.OuraniaAltar]: {
+               commandName: 'runecraft',
+               args: (data: OuraniaAltarOptions) => ({
+                       rune: 'ourania altar',
+                       usestams: data.stamina,
+                       daeyalt_essence: data.daeyalt,
+                       quantity: data.quantity,
+                       fletch: data.fletch?.id
+               })
+       },
 	[activity_type_enum.Runecraft]: {
 		commandName: 'runecraft',
 		args: (data: RunecraftActivityTaskOptions) => ({

--- a/src/mahoji/commands/runecraft.ts
+++ b/src/mahoji/commands/runecraft.ts
@@ -14,6 +14,7 @@ import { determineRunes } from '../../lib/util/determineRunes';
 import { getOSItem } from '../../lib/util/getOSItem';
 import { formatSkillRequirements } from '../../lib/util/smallUtils';
 import { updateBankSetting } from '../../lib/util/updateBankSetting';
+import { zeroTimeFletchables } from '../../lib/skilling/skills/fletching/fletchables';
 import { ouraniaAltarStartCommand } from '../lib/abstracted_commands/ouraniaAltarCommand';
 import { tiaraRunecraftCommand } from '../lib/abstracted_commands/tiaraRunecraftCommand';
 import { calcMaxRCQuantity, userHasGracefulEquipped } from '../mahojiSettings';
@@ -78,26 +79,39 @@ export const runecraftCommand: OSBMahojiCommand = {
 			description: 'Set this to true to use daeyalt essence (default false)',
 			required: false
 		},
-		{
-			type: ApplicationCommandOptionType.Boolean,
-			name: 'extracts',
-			description: 'Set this to true to use extracts (default false)',
-			required: false
-		}
-	],
-	run: async ({
-		userID,
-		options,
-		channelID
+               {
+                       type: ApplicationCommandOptionType.Boolean,
+                       name: 'extracts',
+                       description: 'Set this to true to use extracts (default false)',
+                       required: false
+               },
+               {
+                       type: ApplicationCommandOptionType.Integer,
+                       name: 'fletch',
+                       description: 'The item you wish to fletch during the trip (Ourania Altar only)',
+                       required: false,
+                       autocomplete: async (value: number) => {
+                               const search = value?.toString() ?? '';
+                               return zeroTimeFletchables
+                                       .filter(i => i.name.toLowerCase().includes(search.toLowerCase()))
+                                       .map(i => ({ name: i.name, value: i.id }));
+                       }
+               }
+        ],
+        run: async ({
+                userID,
+                options,
+                channelID
 	}: CommandRunOptions<{
 		rune: string;
 		quantity?: number;
-		usestams?: boolean;
-		daeyalt_essence?: boolean;
-		extracts?: boolean;
-	}>) => {
-		const user = await mUserFetch(userID.toString());
-		let { rune, quantity, usestams, daeyalt_essence, extracts } = options;
+               usestams?: boolean;
+               daeyalt_essence?: boolean;
+               extracts?: boolean;
+               fletch?: number;
+        }>) => {
+               const user = await mUserFetch(userID.toString());
+               let { rune, quantity, usestams, daeyalt_essence, extracts, fletch } = options;
 
 		rune = rune.toLowerCase().replace('rune', '').trim();
 
@@ -111,9 +125,9 @@ export const runecraftCommand: OSBMahojiCommand = {
 			return tiaraRunecraftCommand({ user, channelID, name: rune, quantity });
 		}
 
-		if (rune.includes('ourania')) {
-			return ouraniaAltarStartCommand({ user, channelID, quantity, usestams, daeyalt_essence });
-		}
+               if (rune.includes('ourania')) {
+                       return ouraniaAltarStartCommand({ user, channelID, quantity, usestams, daeyalt_essence, fletch });
+               }
 
 		if (rune.includes('(zeah)')) {
 			return darkAltarCommand({ user, channelID, name: rune, extracts });

--- a/src/mahoji/lib/abstracted_commands/ouraniaAltarCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/ouraniaAltarCommand.ts
@@ -3,8 +3,12 @@ import { Time, increaseNumByPercent } from 'e';
 import { Bank, EItem } from 'oldschooljs';
 
 import Runecraft from '../../../lib/skilling/skills/runecraft';
+import { zeroTimeFletchables } from '../../../lib/skilling/skills/fletching/fletchables';
 import { SkillsEnum } from '../../../lib/skilling/types';
+import type { Fletchable } from '../../../lib/skilling/types';
 import type { OuraniaAltarOptions } from '../../../lib/types/minions';
+import type { SlayerTaskUnlocksEnum } from '../../../lib/slayer/slayerUnlocks';
+import { hasSlayerUnlock } from '../../../lib/slayer/slayerUtil';
 import addSubTaskToActivityTask from '../../../lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '../../../lib/util/calcMaxTripLength';
 import { updateBankSetting } from '../../../lib/util/updateBankSetting';
@@ -13,17 +17,19 @@ import { userHasGracefulEquipped } from '../../mahojiSettings';
 const gracefulPenalty = 20;
 
 export async function ouraniaAltarStartCommand({
-	user,
-	channelID,
-	quantity,
-	usestams,
-	daeyalt_essence
+        user,
+        channelID,
+        quantity,
+        usestams,
+       daeyalt_essence,
+       fletch
 }: {
-	user: MUser;
-	channelID: string;
-	quantity?: number;
-	usestams?: boolean;
-	daeyalt_essence?: boolean;
+        user: MUser;
+        channelID: string;
+        quantity?: number;
+        usestams?: boolean;
+       daeyalt_essence?: boolean;
+       fletch?: number;
 }) {
 	let timePerTrip = Time.Minute * 1.05;
 	const stamina: boolean = usestams !== undefined ? usestams : true;
@@ -32,19 +38,43 @@ export async function ouraniaAltarStartCommand({
 	const { bank } = user;
 	const numEssenceOwned = bank.amount('Pure essence');
 	const daeyaltEssenceOwned = bank.amount('Daeyalt essence');
-	const boosts = [];
-	const mageLvl = user.skillLevel(SkillsEnum.Magic);
-	const spellbookSwap = mageLvl > 95;
+       const boosts = [];
+       const mageLvl = user.skillLevel(SkillsEnum.Magic);
+       const spellbookSwap = mageLvl > 95;
 
-	let inventorySize = 28;
-	// For each pouch the user has, increase their inventory size.
-	for (const pouch of Runecraft.pouches) {
-		if (user.skillLevel(SkillsEnum.Runecraft) < pouch.level) continue;
-		if (bank.has(pouch.id)) inventorySize += pouch.capacity - 1;
-		if (bank.has(pouch.id) && pouch.id === EItem.COLOSSAL_POUCH) break;
-	}
+       let fletchable: Fletchable | undefined;
+       let fletchingQuantity = 0;
+       let sets = '';
+       let itemsNeeded: Bank | undefined;
+       const timeToFletchSingleItem = Time.Hour / 25_000;
 
-	if (inventorySize > 28) boosts.push(`+${inventorySize - 28} inv spaces from pouches`);
+       let inventorySize = 28;
+       // For each pouch the user has, increase their inventory size.
+       for (const pouch of Runecraft.pouches) {
+               if (user.skillLevel(SkillsEnum.Runecraft) < pouch.level) continue;
+               if (bank.has(pouch.id)) inventorySize += pouch.capacity - 1;
+               if (bank.has(pouch.id) && pouch.id === EItem.COLOSSAL_POUCH) break;
+       }
+
+       if (fletch) {
+               fletchable = zeroTimeFletchables.find(item => item.id === Number(fletch));
+               if (!fletchable) return 'That is not a valid item to fletch during Ourania Altar.';
+               if (user.skillLevel('fletching') < fletchable.level) {
+                       return `${user.minionName} needs ${fletchable.level} Fletching to fletch ${fletchable.name}.`;
+               }
+               if (fletchable.requiredSlayerUnlocks) {
+                       const { success, errors } = hasSlayerUnlock(
+                               user.user.slayer_unlocks as SlayerTaskUnlocksEnum[],
+                               fletchable.requiredSlayerUnlocks
+                       );
+                       if (!success) {
+                               return `You don't have the required Slayer Unlocks to create this item.\n\nRequired: ${errors}`;
+                       }
+               }
+               inventorySize -= 3;
+       }
+
+       if (inventorySize > 28) boosts.push(`+${inventorySize - 28} inv spaces from pouches`);
 
 	if (!userHasGracefulEquipped(user) || !spellbookSwap) {
 		boosts.push(`${gracefulPenalty}% slower for no Graceful`);
@@ -82,17 +112,30 @@ export async function ouraniaAltarStartCommand({
 		}
 	}
 
-	const numberOfInventories = Math.max(Math.ceil(quantity / inventorySize), 1);
-	const duration = numberOfInventories * timePerTrip;
+       const numberOfInventories = Math.max(Math.ceil(quantity / inventorySize), 1);
+       const duration = numberOfInventories * timePerTrip;
 
-	if (duration > maxTripLength) {
+       if (duration > maxTripLength) {
 		return `${user.minionName} can't go on trips longer than ${formatDuration(
 			maxTripLength
 		)}, try a lower quantity. The highest amount of essence you can craft is ${Math.floor(maxCanDo)}.`;
 	}
 
-	const totalCost = new Bank();
-	const itemCost = new Bank();
+       const totalCost = new Bank();
+       const itemCost = new Bank();
+
+       if (fletchable) {
+               fletchingQuantity = Math.floor(duration / timeToFletchSingleItem);
+               if (fletchable.outputMultiple) sets = ' sets of';
+               const max = user.bank.fits(fletchable.inputItems);
+               if (max < fletchingQuantity && max !== 0) fletchingQuantity = max;
+               itemsNeeded = fletchable.inputItems.clone().multiply(fletchingQuantity);
+               if (!user.bankWithGP.has(itemsNeeded)) {
+                       return `You don't have enough items. For ${fletchingQuantity}x ${fletchable.name}, you're missing **${itemsNeeded
+                               .clone()
+                               .remove(user.bank)}**.`;
+               }
+       }
 
 	if (stamina || spellbookSwap) {
 		if (spellbookSwap) {
@@ -110,26 +153,29 @@ export async function ouraniaAltarStartCommand({
 		}
 	}
 
-	if (daeyalt_essence) {
-		totalCost.add('Daeyalt essence', quantity);
-		if (!user.owns(totalCost)) return `You don't own: ${totalCost}.`;
-	} else {
-		totalCost.add('Pure essence', quantity);
-	}
-	if (!user.owns(totalCost)) return `You don't own: ${totalCost}.`;
+       if (daeyalt_essence) {
+               totalCost.add('Daeyalt essence', quantity);
+               if (!user.owns(totalCost)) return `You don't own: ${totalCost}.`;
+       } else {
+               totalCost.add('Pure essence', quantity);
+       }
+       if (!user.owns(totalCost)) return `You don't own: ${totalCost}.`;
+       await user.removeItemsFromBank(totalCost);
+       if (itemsNeeded) {
+               await user.removeItemsFromBank(itemsNeeded);
+       }
+       updateBankSetting('runecraft_cost', totalCost);
 
-	await user.removeItemsFromBank(totalCost);
-	updateBankSetting('runecraft_cost', totalCost);
-
-	await addSubTaskToActivityTask<OuraniaAltarOptions>({
-		quantity,
-		userID: user.id,
-		duration,
-		type: 'OuraniaAltar',
-		channelID: channelID.toString(),
-		stamina,
-		daeyalt
-	});
+       await addSubTaskToActivityTask<OuraniaAltarOptions>({
+               quantity,
+               userID: user.id,
+               duration,
+               type: 'OuraniaAltar',
+               channelID: channelID.toString(),
+               stamina,
+               daeyalt,
+               fletch: fletchable ? { id: fletchable.id, qty: fletchingQuantity } : undefined
+       });
 
 	let response = `${user.minionName} is now crafting ${quantity}x`;
 
@@ -139,11 +185,15 @@ export async function ouraniaAltarStartCommand({
 		response += ' Pure ';
 	}
 
-	response += `Essence at the Ourania Altar, it'll take around ${formatDuration(
-		duration
-	)} to finish, this will take ${numberOfInventories}x trips to the altar.\nYour minion has consumed: ${itemCost}.\n\n**Boosts:** ${boosts.join(
-		', '
-	)}`;
+       response += `Essence at the Ourania Altar, it'll take around ${formatDuration(
+               duration
+       )} to finish, this will take ${numberOfInventories}x trips to the altar.\nYour minion has consumed: ${itemCost}.`;
+
+       if (fletchable && itemsNeeded) {
+               response += `\nYou are also now Fletching ${fletchingQuantity}${sets} ${fletchable.name}. Removed ${itemsNeeded} from your bank.`;
+       }
+
+       response += `\n\n**Boosts:** ${boosts.join(', ')}`;
 
 	return response;
 }


### PR DESCRIPTION
## Summary
- allow specifying a zero-time fletchable when runecrafting at the Ourania altar
- reduce inventory by 3 and fletch up to 25k items/hour while crafting
- document new Ourania fletching support

## Testing
- `pnpm test` *(fails: Failed to resolve entry for package "oldschooljs".)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c939e0d88326a4e012e9c7745d6a