### PR TITLE
Add Yeti to PvM collection log

### DIFF
--- a/src/lib/data/Collections.ts
+++ b/src/lib/data/Collections.ts
@@ -210,6 +210,7 @@ import {
 	vladDrakanCL,
 	volcanicMineCL,
 	vorkathCL,
+	yetiCL,
 	wintertodtCL,
 	zalcanoCL,
 	zulrahCL
@@ -748,6 +749,12 @@ export const allCollectionLogs: ICollection = {
 				allItems: BSOMonsters.Treebeard.table.allItems,
 				items: treeBeardCL,
 				fmtProg: kcProg(BSOMonsters.Treebeard.id)
+			},
+			Yeti: {
+				alias: BSOMonsters.Yeti.aliases,
+				allItems: BSOMonsters.Yeti.table.allItems,
+				items: yetiCL,
+				fmtProg: kcProg(BSOMonsters.Yeti.id)
 			},
 			'Sea Kraken': {
 				alias: BSOMonsters.SeaKraken.aliases,

--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -2466,6 +2466,14 @@ export const kalphiteKingCL = resolveItems([
 
 export const ignecarusCL = resolveItems(['Ignecarus scales', 'Ignecarus dragonclaw', 'Dragon egg', 'Ignis ring']);
 
+export const yetiCL = resolveItems([
+        'Raw yeti meat',
+        'Yeti hide',
+        'Frostclaw cape',
+        'Cold heart',
+        'Penguin egg'
+]);
+
 export const treeBeardCL = resolveItems([
 	// Tangleroot pets
 	20_661,


### PR DESCRIPTION
## Summary
- add a `yetiCL` collection definition covering the unique loot from Yeti
- register Yeti under the PvM collection log so its drops count toward the tab

## Testing
- pnpm lint *(fails: missing module /workspace/oldschoolbot/node_modules/@oldschoolgg/toolkit/dist/cjs/structures.cjs)*
