### PR TITLE
feat: add barblore fishing method

### DIFF
--- a/docs/src/content/docs/osb/Skills/fishing.mdx
+++ b/docs/src/content/docs/osb/Skills/fishing.mdx
@@ -37,6 +37,7 @@ Equipping the following tools in **any** setup reduces catch time:
 ### Fish
 
 - [[/fish name\:Barbarian fishing]] — for Barbarian Fishing
+- [[/fish name\:Barbarian fishing barblore\:true]] — perform Barbarian fishing while making Barbarian mixes for additional Cooking and Herblore XP
 - **Karambwanji** (bait for Karambwan) requires **15 QP**
 - **Monkfish** requires **100 QP**
 - **Anglerfish** requires **40 QP**

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -845,6 +845,7 @@ enum activity_type_enum {
   GroupMonsterKilling
   ClueCompletion
   Fishing
+  BarbloreFishing
   Mining
   Smithing
   Woodcutting

--- a/src/lib/Task.ts
+++ b/src/lib/Task.ts
@@ -28,6 +28,7 @@ import { enchantingTask } from '../tasks/minions/enchantingActivity';
 import { farmingTask } from '../tasks/minions/farmingActivity';
 import { firemakingTask } from '../tasks/minions/firemakingActivity';
 import { fishingTask } from '../tasks/minions/fishingActivity';
+import { barbloreTask } from '../tasks/minions/barbloreActivity';
 import { fletchingTask } from '../tasks/minions/fletchingActivity';
 import { CreateForestersRationsTask } from '../tasks/minions/forestersRationActivity';
 import { gloryChargingTask } from '../tasks/minions/gloryChargingActivity';
@@ -135,10 +136,11 @@ export const allTasks: MinionTask[] = [
 	castingTask,
 	clueTask,
 	collectingTask,
-	constructionTask,
-	cookingTask,
-	craftingTask,
-	darkAltarTask,
+        constructionTask,
+        cookingTask,
+        craftingTask,
+        barbloreTask,
+        darkAltarTask,
 	ouraniaAltarTask,
 	enchantingTask,
 	farmingTask,

--- a/src/lib/skilling/skills/fishing/barbloreTripStart.ts
+++ b/src/lib/skilling/skills/fishing/barbloreTripStart.ts
@@ -1,0 +1,293 @@
+import { Time } from '@oldschoolgg/toolkit/datetime';
+import { Bank, itemID } from 'oldschooljs';
+
+import type { GearBank } from '@/lib/structures/GearBank';
+import type { Mixable } from '@/lib/skilling/types';
+import { logError } from '@/lib/util/logError';
+
+import type { Fish } from '../../types';
+import { barbMixes } from '@/lib/skilling/skills/herblore/mixables/barbMixes';
+import { calcFishingTripStart } from './fishingTripStart';
+
+const ROE_ID = itemID('Roe');
+const CAVIAR_ID = itemID('Caviar');
+
+let hasEnsuredActivityType = false;
+
+export async function ensureBarbloreActivityType() {
+if (hasEnsuredActivityType) {
+return;
+}
+try {
+await prisma.$executeRawUnsafe(
+`ALTER TYPE "activity_type_enum" ADD VALUE IF NOT EXISTS 'BarbloreFishing';`
+);
+} catch (error) {
+logError(error, { context: 'ensureBarbloreActivityType' });
+} finally {
+hasEnsuredActivityType = true;
+}
+}
+
+interface MixPlan {
+ingredient: 'Roe' | 'Caviar';
+mix: Mixable;
+potionID: number;
+potionName: string;
+quantity: number;
+}
+
+export interface BarbloreTripStartResult {
+cost: Bank;
+duration: number;
+quantity: number;
+boosts: string[];
+xp: {
+fishing: number;
+agility: number;
+strength: number;
+herblore: number;
+cooking: number;
+};
+xpPerHour: {
+fishing: number;
+agility: number;
+strength: number;
+herblore: number;
+cooking: number;
+};
+mixPlan: MixPlan[];
+leftoverFish: {
+trout: number;
+salmon: number;
+sturgeon: number;
+};
+leftoverIngredients: {
+roe: number;
+caviar: number;
+};
+ingredientsUsed: {
+roe: number;
+caviar: number;
+};
+fishOffcuts: number;
+originalQuantity?: number;
+}
+
+function pickBestMix(
+mixes: Mixable[],
+ingredient: 'Roe' | 'Caviar',
+herbloreLevel: number,
+bank: GearBank['bank']
+): (MixPlan & { available: number }) | null {
+const filtered = mixes
+.filter(mix => mix.level <= herbloreLevel)
+.sort((a, b) => b.xp - a.xp);
+for (const mix of filtered) {
+const potionEntry = mix
+.inputItems
+.items()
+.find(([item]) => item.id !== (ingredient === 'Roe' ? ROE_ID : CAVIAR_ID));
+if (!potionEntry) {
+continue;
+}
+const [potionItem] = potionEntry;
+const available = bank.amount(potionItem.id);
+if (available > 0) {
+return {
+ingredient,
+mix,
+potionID: potionItem.id,
+potionName: potionItem.name,
+quantity: 0,
+available
+};
+}
+}
+return null;
+}
+
+export function calcBarbloreTripStart({
+gearBank,
+fish,
+maxTripLength,
+quantityInput,
+wantsToUseFlakes
+}: {
+gearBank: GearBank;
+fish: Fish;
+maxTripLength: number;
+quantityInput: number | undefined;
+wantsToUseFlakes: boolean;
+}): string | BarbloreTripStartResult {
+if (wantsToUseFlakes) {
+return 'Spirit flakes cannot be used with the Barblore method.';
+}
+const baseStart = calcFishingTripStart({
+gearBank,
+fish,
+maxTripLength,
+quantityInput,
+wantsToUseFlakes: false
+});
+if (typeof baseStart === 'string') {
+return baseStart;
+}
+const cost = new Bank(baseStart.cost);
+const boosts = [...baseStart.boosts];
+const quantity = baseStart.quantity;
+const duration = baseStart.duration;
+
+const stats = gearBank.skillsAsLevels;
+const fishingLevel = stats.fishing;
+const agilityLevel = stats.agility;
+const strengthLevel = stats.strength;
+const cookingLevel = stats.cooking;
+const herbloreLevel = stats.herblore;
+
+const canSturgeon =
+fishingLevel >= 70 && agilityLevel >= 45 && strengthLevel >= 45;
+const canSalmon =
+fishingLevel >= 58 && agilityLevel >= 30 && strengthLevel >= 30;
+
+const sturgeonChance = canSturgeon ? 255 / (8 + Math.floor(0.5714 * fishingLevel)) : null;
+const salmonChance = canSalmon ? 255 / (16 + Math.floor(0.8616 * fishingLevel)) : null;
+const troutChance = 255 / (32 + Math.floor(1.632 * fishingLevel));
+
+const sturgeonProbability = sturgeonChance ? 1 / sturgeonChance : 0;
+const salmonProbability = salmonChance ? 1 / salmonChance : 0;
+const troutProbability = 1 / troutChance;
+
+const sturgeonCount = Math.min(quantity, Math.round(quantity * sturgeonProbability));
+const remainingAfterSturgeon = Math.max(0, quantity - sturgeonCount);
+const salmonCount = Math.min(
+remainingAfterSturgeon,
+Math.round(remainingAfterSturgeon * salmonProbability)
+);
+const remainingAfterSalmon = Math.max(0, remainingAfterSturgeon - salmonCount);
+const troutCount = remainingAfterSalmon;
+
+const fishingXP = sturgeonCount * 80 + salmonCount * 70 + troutCount * 50;
+const agilityXP = sturgeonCount * 7 + salmonCount * 6 + troutCount * 5;
+const strengthXP = agilityXP;
+
+const troutRoeChance = Math.min(1, (0.67 * cookingLevel) / 100);
+const salmonRoeChance = Math.min(1, (1.25 * cookingLevel) / 100);
+const sturgeonCaviarChance = Math.min(1, (1.25 * cookingLevel) / 100);
+
+const roeFromTrout = Math.min(troutCount, Math.round(troutCount * troutRoeChance));
+const roeFromSalmon = Math.min(salmonCount, Math.round(salmonCount * salmonRoeChance));
+const caviarFromSturgeon = Math.min(
+sturgeonCount,
+Math.round(sturgeonCount * sturgeonCaviarChance)
+);
+
+const totalRoe = roeFromTrout + roeFromSalmon;
+const totalCaviar = caviarFromSturgeon;
+
+const cookingXP = roeFromTrout * 10 + roeFromSalmon * 10 + caviarFromSturgeon * 15;
+
+const roeMixes = barbMixes.filter(mix => mix.inputItems.has('Roe'));
+const caviarMixes = barbMixes.filter(mix => mix.inputItems.has('Caviar'));
+
+const roeMixPlan = pickBestMix(roeMixes, 'Roe', herbloreLevel, gearBank.bank);
+const caviarMixPlan = pickBestMix(caviarMixes, 'Caviar', herbloreLevel, gearBank.bank);
+
+const mixPlan: MixPlan[] = [];
+let herbloreXP = 0;
+let roeUsed = 0;
+let caviarUsed = 0;
+
+if (roeMixPlan) {
+const quantityToMake = Math.min(totalRoe, roeMixPlan.available);
+if (quantityToMake > 0) {
+cost.add(roeMixPlan.potionID, quantityToMake);
+mixPlan.push({
+ingredient: 'Roe',
+mix: roeMixPlan.mix,
+potionID: roeMixPlan.potionID,
+potionName: roeMixPlan.potionName,
+quantity: quantityToMake
+});
+herbloreXP += quantityToMake * roeMixPlan.mix.xp;
+roeUsed = quantityToMake;
+}
+}
+
+if (caviarMixPlan) {
+const quantityToMake = Math.min(totalCaviar, caviarMixPlan.available);
+if (quantityToMake > 0) {
+cost.add(caviarMixPlan.potionID, quantityToMake);
+mixPlan.push({
+ingredient: 'Caviar',
+mix: caviarMixPlan.mix,
+potionID: caviarMixPlan.potionID,
+potionName: caviarMixPlan.potionName,
+quantity: quantityToMake
+});
+herbloreXP += quantityToMake * caviarMixPlan.mix.xp;
+caviarUsed = quantityToMake;
+}
+}
+
+if (mixPlan.length === 0) {
+return 'You need suitable (2) dose potions in your bank to create Barbarian mixes for Barblore.';
+}
+
+const leftoverRoe = Math.max(0, totalRoe - roeUsed);
+const leftoverCaviar = Math.max(0, totalCaviar - caviarUsed);
+
+const fishOffcuts =
+Math.floor(roeFromTrout * 0.5) +
+Math.floor(roeFromSalmon * 0.75) +
+Math.floor(caviarFromSturgeon * (5 / 6));
+
+const leftoverFish = {
+trout: Math.max(0, troutCount - roeFromTrout),
+salmon: Math.max(0, salmonCount - roeFromSalmon),
+sturgeon: Math.max(0, sturgeonCount - caviarFromSturgeon)
+};
+
+if (mixPlan.length > 0) {
+const mixSummary = mixPlan
+.map(plan => `${plan.quantity.toLocaleString()}x ${plan.mix.item.name}`)
+.join(', ');
+boosts.push(`Barblore mixes: ${mixSummary}`);
+}
+
+const xp = {
+fishing: fishingXP,
+agility: agilityXP,
+strength: strengthXP,
+herblore: herbloreXP,
+cooking: cookingXP
+};
+
+const xpPerHour = {
+fishing: duration > 0 ? Math.floor((xp.fishing * Time.Hour) / duration) : 0,
+agility: duration > 0 ? Math.floor((xp.agility * Time.Hour) / duration) : 0,
+strength: duration > 0 ? Math.floor((xp.strength * Time.Hour) / duration) : 0,
+herblore: duration > 0 ? Math.floor((xp.herblore * Time.Hour) / duration) : 0,
+cooking: duration > 0 ? Math.floor((xp.cooking * Time.Hour) / duration) : 0
+};
+
+boosts.push(
+`XP/hr — Fishing: ${xpPerHour.fishing.toLocaleString()}, Agility: ${xpPerHour.agility.toLocaleString()}, Strength: ${xpPerHour.strength.toLocaleString()}, Cooking: ${xpPerHour.cooking.toLocaleString()}, Herblore: ${xpPerHour.herblore.toLocaleString()}`
+);
+
+return {
+cost,
+duration,
+quantity,
+boosts,
+xp,
+xpPerHour,
+mixPlan,
+leftoverFish,
+leftoverIngredients: { roe: leftoverRoe, caviar: leftoverCaviar },
+ingredientsUsed: { roe: roeUsed, caviar: caviarUsed },
+fishOffcuts,
+originalQuantity: quantityInput
+};
+}
+

--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -163,11 +163,56 @@ export interface ClueActivityTaskOptions extends ActivityTaskOptions {
 }
 
 export interface FishingActivityTaskOptions extends ActivityTaskOptions {
-	type: 'Fishing';
-	fishID: number;
-	quantity: number;
-	flakesQuantity?: number;
-	iQty?: number;
+        type: 'Fishing';
+        fishID: number;
+        quantity: number;
+        flakesQuantity?: number;
+        iQty?: number;
+}
+
+export interface BarbloreActivityTaskOptions extends ActivityTaskOptions {
+        type: 'BarbloreFishing';
+        fishID: number;
+        quantity: number;
+        xp: {
+                fishing: number;
+                agility: number;
+                strength: number;
+                herblore: number;
+                cooking: number;
+        };
+        xpPerHour: {
+                fishing: number;
+                agility: number;
+                strength: number;
+                herblore: number;
+                cooking: number;
+        };
+        mixPlan: {
+                ingredient: 'Roe' | 'Caviar';
+                mixID: number;
+                mixName: string;
+                potionID: number;
+                potionName: string;
+                quantity: number;
+                xpPerMix: number;
+        }[];
+        leftoverFish: {
+                trout: number;
+                salmon: number;
+                sturgeon: number;
+        };
+        leftoverIngredients: {
+                roe: number;
+                caviar: number;
+        };
+        ingredientsUsed: {
+                roe: number;
+                caviar: number;
+        };
+        fishOffcuts: number;
+        boosts: string[];
+        iQty?: number;
 }
 
 export interface MiningActivityTaskOptions extends ActivityTaskOptions {
@@ -621,11 +666,12 @@ export type ActivityTaskData =
 	| ScatteringActivityTaskOptions
 	| OfferingActivityTaskOptions
 	| AnimatedArmourActivityTaskOptions
-	| CookingActivityTaskOptions
-	| CraftingActivityTaskOptions
-	| FiremakingActivityTaskOptions
-	| FishingActivityTaskOptions
-	| MiningActivityTaskOptions
+        | CookingActivityTaskOptions
+        | CraftingActivityTaskOptions
+        | FiremakingActivityTaskOptions
+        | BarbloreActivityTaskOptions
+        | FishingActivityTaskOptions
+        | MiningActivityTaskOptions
 	| MotherlodeMiningActivityTaskOptions
 	| PlunderActivityTaskOptions
 	| SmithingActivityTaskOptions

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -50,8 +50,9 @@ import type {
 	EnchantingActivityTaskOptions,
 	FarmingActivityTaskOptions,
 	FightCavesActivityTaskOptions,
-	FiremakingActivityTaskOptions,
-	FishingActivityTaskOptions,
+        FiremakingActivityTaskOptions,
+        FishingActivityTaskOptions,
+        BarbloreActivityTaskOptions,
 	FletchingActivityTaskOptions,
 	GauntletOptions,
 	GroupMonsterActivityTaskOptions,
@@ -148,15 +149,26 @@ export function minionStatus(user: MUser) {
 			} Cooking level is ${user.skillLevel(SkillsEnum.Cooking)}`;
 		}
 
-		case 'Fishing': {
-			const data = currentTask as FishingActivityTaskOptions;
+                case 'Fishing': {
+                        const data = currentTask as FishingActivityTaskOptions;
 
-			const fish = Fishing.Fishes.find(fish => fish.id === data.fishID);
+                        const fish = Fishing.Fishes.find(fish => fish.id === data.fishID);
 
-			return `${name} is currently fishing ${data.quantity}x ${fish?.name}. ${formattedDuration} Your ${
-				Emoji.Fishing
-			} Fishing level is ${user.skillLevel(SkillsEnum.Fishing)}`;
-		}
+                        return `${name} is currently fishing ${data.quantity}x ${fish?.name}. ${formattedDuration} Your ${
+                                Emoji.Fishing
+                        } Fishing level is ${user.skillLevel(SkillsEnum.Fishing)}`;
+                }
+
+                case 'BarbloreFishing': {
+                        const data = currentTask as BarbloreActivityTaskOptions;
+                        const fish = Fishing.Fishes.find(_fish => _fish.id === data.fishID);
+                        const mixSummary = data.mixPlan
+                                .filter(plan => plan.quantity > 0)
+                                .map(plan => `${plan.quantity.toLocaleString()}x ${plan.mixName}`)
+                                .join(', ');
+                        const mixPart = mixSummary.length > 0 ? ` They are creating ${mixSummary}.` : '';
+                        return `${name} is currently training Barblore while fishing ${fish?.name}. ${formattedDuration}${mixPart}`;
+                }
 
 		case 'Mining': {
 			const data = currentTask as MiningActivityTaskOptions;

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -32,7 +32,8 @@ import type {
 	EnchantingActivityTaskOptions,
 	FarmingActivityTaskOptions,
 	FiremakingActivityTaskOptions,
-	FishingActivityTaskOptions,
+        FishingActivityTaskOptions,
+        BarbloreActivityTaskOptions,
 	FletchingActivityTaskOptions,
 	GauntletOptions,
 	GiantsFoundryActivityTaskOptions,
@@ -68,6 +69,9 @@ import type {
 import { giantsFoundryAlloys } from './../../mahoji/lib/abstracted_commands/giantsFoundryCommand';
 import type { NightmareZoneActivityTaskOptions, UnderwaterAgilityThievingTaskOptions } from './../types/minions';
 import { interactionReply } from './interactionReply';
+
+const BARBLORE_ACTIVITY_TYPE =
+        (activity_type_enum as any).BarbloreFishing ?? ('BarbloreFishing' as activity_type_enum);
 
 const taskCanBeRepeated = (activity: Activity, user: MUser) => {
 	if (activity.type === activity_type_enum.ClueCompletion) {
@@ -349,17 +353,28 @@ const tripHandlers = {
 			quantity: data.quantity
 		})
 	},
-	[activity_type_enum.Fishing]: {
-		commandName: 'fish',
-		args: (data: FishingActivityTaskOptions) => {
-			const fish = Fishing.Fishes.find(f => f.id === (data.fishID as number));
-			return {
-				name: fish ? fish.name : Items.itemNameFromId(data.fishID),
-				quantity: data.iQty,
-				flakes: data.flakesQuantity !== undefined
-			};
-		}
-	},
+        [activity_type_enum.Fishing]: {
+                commandName: 'fish',
+                args: (data: FishingActivityTaskOptions) => {
+                        const fish = Fishing.Fishes.find(f => f.id === (data.fishID as number));
+                        return {
+                                name: fish ? fish.name : Items.itemNameFromId(data.fishID),
+                                quantity: data.iQty,
+                                flakes: data.flakesQuantity !== undefined
+                        };
+                }
+        },
+        [BARBLORE_ACTIVITY_TYPE]: {
+                commandName: 'fish',
+                args: (data: BarbloreActivityTaskOptions) => {
+                        const fish = Fishing.Fishes.find(f => f.id === (data.fishID as number));
+                        return {
+                                name: fish ? fish.name : Items.itemNameFromId(data.fishID),
+                                quantity: data.iQty,
+                                barblore: true
+                        };
+                }
+        },
 	[activity_type_enum.FishingTrawler]: {
 		commandName: 'minigames',
 		args: () => ({ fishing_trawler: { start: {} } })

--- a/src/mahoji/commands/fish.ts
+++ b/src/mahoji/commands/fish.ts
@@ -2,11 +2,12 @@ import { type CommandRunOptions, formatDuration, stringSearch } from '@oldschool
 import { ApplicationCommandOptionType } from 'discord.js';
 import { ItemGroups, Monsters } from 'oldschooljs';
 
-import type { FishingActivityTaskOptions } from '@/lib/types/minions';
+import type { BarbloreActivityTaskOptions, FishingActivityTaskOptions } from '@/lib/types/minions';
 import addSubTaskToActivityTask from '@/lib/util/addSubTaskToActivityTask';
 import { calcMaxTripLength } from '@/lib/util/calcMaxTripLength';
 import type { OSBMahojiCommand } from '@oldschoolgg/toolkit/discord-util';
 import { Fishing } from '../../lib/skilling/skills/fishing/fishing';
+import { calcBarbloreTripStart, ensureBarbloreActivityType } from '../../lib/skilling/skills/fishing/barbloreTripStart';
 
 export const fishCommand: OSBMahojiCommand = {
 	name: 'fish',
@@ -43,18 +44,24 @@ export const fishCommand: OSBMahojiCommand = {
 			name: 'flakes',
 			description: 'Use spirit flakes?',
 			required: false
-		}
-	],
-	run: async ({
-		options,
-		userID,
-		channelID
-	}: CommandRunOptions<{ name: string; quantity?: number; flakes?: boolean }>) => {
-		const fish = Fishing.Fishes.find(fish => stringSearch(fish.name, options.name));
-		if (!fish) return 'Thats not a valid fish to catch.';
+                },
+                {
+                        type: ApplicationCommandOptionType.Boolean,
+                        name: 'barblore',
+                        description: 'Combine Barbarian fishing with Barbarian mixes for extra XP.',
+                        required: false
+                }
+        ],
+        run: async ({
+                options,
+                userID,
+                channelID
+        }: CommandRunOptions<{ name: string; quantity?: number; flakes?: boolean; barblore?: boolean }>) => {
+                const fish = Fishing.Fishes.find(fish => stringSearch(fish.name, options.name));
+                if (!fish) return 'Thats not a valid fish to catch.';
 
-		const user = await mUserFetch(userID);
-		if (user.skillsAsLevels.fishing < fish.level) {
+                const user = await mUserFetch(userID);
+                if (user.skillsAsLevels.fishing < fish.level) {
 			return `${user.minionName} needs ${fish.level} Fishing to fish ${fish.name}.`;
 		}
 
@@ -80,47 +87,110 @@ export const fishCommand: OSBMahojiCommand = {
 			return 'You need to own the Angler Outfit to fish for Minnows.';
 		}
 
-		const maxTripLength = calcMaxTripLength(user, 'Fishing');
+                const maxTripLength = calcMaxTripLength(user, 'Fishing');
 
-		const res = Fishing.util.calcFishingTripStart({
-			gearBank: user.gearBank,
-			fish,
-			maxTripLength,
-			quantityInput: options.quantity,
-			wantsToUseFlakes: Boolean(options.flakes)
-		});
-		if (typeof res === 'string') {
-			return res;
-		}
+                if (options.barblore) {
+                        if (fish.name !== 'Barbarian fishing') {
+                                return 'The Barblore method can only be used while Barbarian fishing.';
+                        }
 
-		if (res.cost.length > 0) {
-			if (!user.owns(res.cost)) {
-				return `You don't own the required items to fish ${fish.name}, you need: ${res.cost}.`;
-			}
-			await user.transactItems({
-				itemsToRemove: res.cost
-			});
-		}
+                        const res = calcBarbloreTripStart({
+                                gearBank: user.gearBank,
+                                fish,
+                                maxTripLength,
+                                quantityInput: options.quantity,
+                                wantsToUseFlakes: Boolean(options.flakes)
+                        });
+                        if (typeof res === 'string') {
+                                return res;
+                        }
 
-		await addSubTaskToActivityTask<FishingActivityTaskOptions>({
-			fishID: fish.id,
-			userID: user.id,
-			channelID,
-			quantity: res.quantity,
-			iQty: options.quantity ? options.quantity : undefined,
-			duration: res.duration,
-			type: 'Fishing',
-			flakesQuantity: res.flakesBeingUsed
-		});
+                        if (!user.owns(res.cost)) {
+                                return `You don't own the required items to fish ${fish.name}, you need: ${res.cost}.`;
+                        }
 
-		let response = `${user.minionName} is now fishing ${res.quantity}x ${fish.name}, it'll take around ${formatDuration(
-			res.duration
-		)} to finish.`;
+                        await user.transactItems({
+                                itemsToRemove: res.cost
+                        });
 
-		if (res.boosts.length > 0) {
-			response += `\n\n**Boosts:** ${res.boosts.join(', ')}.`;
-		}
+                        await ensureBarbloreActivityType();
 
-		return response;
-	}
+                        await addSubTaskToActivityTask<BarbloreActivityTaskOptions>({
+                                type: 'BarbloreFishing' as any,
+                                fishID: fish.id,
+                                userID: user.id,
+                                channelID,
+                                quantity: res.quantity,
+                                duration: res.duration,
+                                iQty: res.originalQuantity,
+                                xp: res.xp,
+                                xpPerHour: res.xpPerHour,
+                                mixPlan: res.mixPlan.map(plan => ({
+                                        ingredient: plan.ingredient,
+                                        mixID: plan.mix.item.id,
+                                        mixName: plan.mix.item.name,
+                                        potionID: plan.potionID,
+                                        potionName: plan.potionName,
+                                        quantity: plan.quantity,
+                                        xpPerMix: plan.mix.xp
+                                })),
+                                leftoverFish: res.leftoverFish,
+                                leftoverIngredients: res.leftoverIngredients,
+                                ingredientsUsed: res.ingredientsUsed,
+                                fishOffcuts: res.fishOffcuts,
+                                boosts: res.boosts
+                        });
+
+                        let response = `${user.minionName} is now performing Barblore with ${res.quantity}x ${fish.name}, it'll take around ${formatDuration(
+                                res.duration
+                        )} to finish.`;
+
+                        if (res.boosts.length > 0) {
+                                response += `\n\n**Boosts:** ${res.boosts.join(', ')}.`;
+                        }
+
+                        return response;
+                }
+
+                const res = Fishing.util.calcFishingTripStart({
+                        gearBank: user.gearBank,
+                        fish,
+                        maxTripLength,
+                        quantityInput: options.quantity,
+                        wantsToUseFlakes: Boolean(options.flakes)
+                });
+                if (typeof res === 'string') {
+                        return res;
+                }
+
+                if (res.cost.length > 0) {
+                        if (!user.owns(res.cost)) {
+                                return `You don't own the required items to fish ${fish.name}, you need: ${res.cost}.`;
+                        }
+                        await user.transactItems({
+                                itemsToRemove: res.cost
+                        });
+                }
+
+                await addSubTaskToActivityTask<FishingActivityTaskOptions>({
+                        fishID: fish.id,
+                        userID: user.id,
+                        channelID,
+                        quantity: res.quantity,
+                        iQty: options.quantity ? options.quantity : undefined,
+                        duration: res.duration,
+                        type: 'Fishing',
+                        flakesQuantity: res.flakesBeingUsed
+                });
+
+                let response = `${user.minionName} is now fishing ${res.quantity}x ${fish.name}, it'll take around ${formatDuration(
+                        res.duration
+                )} to finish.`;
+
+                if (res.boosts.length > 0) {
+                        response += `\n\n**Boosts:** ${res.boosts.join(', ')}.`;
+                }
+
+                return response;
+        }
 };

--- a/src/tasks/minions/barbloreActivity.ts
+++ b/src/tasks/minions/barbloreActivity.ts
@@ -1,0 +1,118 @@
+import { Bank } from 'oldschooljs';
+
+import { SkillsEnum } from '@/lib/skilling/types';
+import type { BarbloreActivityTaskOptions } from '@/lib/types/minions';
+
+export const barbloreTask: MinionTask = {
+type: 'BarbloreFishing' as any,
+isNew: true,
+async run(data: BarbloreActivityTaskOptions, { user, handleTripFinish }) {
+const { channelID } = data;
+
+const loot = new Bank();
+
+for (const plan of data.mixPlan) {
+if (plan.quantity > 0) {
+loot.add(plan.mixID, plan.quantity);
+}
+}
+
+if (data.leftoverFish.trout > 0) {
+loot.add('Leaping trout', data.leftoverFish.trout);
+}
+if (data.leftoverFish.salmon > 0) {
+loot.add('Leaping salmon', data.leftoverFish.salmon);
+}
+if (data.leftoverFish.sturgeon > 0) {
+loot.add('Leaping sturgeon', data.leftoverFish.sturgeon);
+}
+
+if (data.leftoverIngredients.roe > 0) {
+loot.add('Roe', data.leftoverIngredients.roe);
+}
+if (data.leftoverIngredients.caviar > 0) {
+loot.add('Caviar', data.leftoverIngredients.caviar);
+}
+
+if (data.fishOffcuts > 0) {
+loot.add('Fish offcuts', data.fishOffcuts);
+}
+
+const xpMessages: string[] = [];
+
+if (data.xp.fishing > 0) {
+const message = await user.addXP({
+skillName: SkillsEnum.Fishing,
+amount: data.xp.fishing,
+duration: data.duration
+});
+if (message) xpMessages.push(message);
+}
+if (data.xp.agility > 0) {
+const message = await user.addXP({
+skillName: SkillsEnum.Agility,
+amount: data.xp.agility,
+duration: data.duration
+});
+if (message) xpMessages.push(message);
+}
+if (data.xp.strength > 0) {
+const message = await user.addXP({
+skillName: SkillsEnum.Strength,
+amount: data.xp.strength,
+duration: data.duration
+});
+if (message) xpMessages.push(message);
+}
+if (data.xp.cooking > 0) {
+const message = await user.addXP({
+skillName: SkillsEnum.Cooking,
+amount: data.xp.cooking,
+duration: data.duration
+});
+if (message) xpMessages.push(message);
+}
+if (data.xp.herblore > 0) {
+const message = await user.addXP({
+skillName: SkillsEnum.Herblore,
+amount: data.xp.herblore,
+duration: data.duration
+});
+if (message) xpMessages.push(message);
+}
+
+await transactItems({
+userID: user.id,
+itemsToAdd: loot,
+collectionLog: true
+});
+
+const mixSummary =
+data.mixPlan.length > 0
+? data.mixPlan
+.filter(plan => plan.quantity > 0)
+.map(plan => `${plan.quantity.toLocaleString()}x ${plan.mixName}`)
+.join(', ')
+: null;
+
+let str = `${user}, ${user.minionName} finished a Barblore fishing trip covering ${data.quantity.toLocaleString()} actions.`;
+
+if (mixSummary) {
+str += ` They created ${mixSummary}.`;
+}
+
+if (xpMessages.length > 0) {
+str += `\n${xpMessages.join('\n')}`;
+}
+
+if (loot.length > 0) {
+str += `\n\nYou received: ${loot}.`;
+}
+
+if (data.boosts.length > 0) {
+str += `\n\n**Boosts:** ${data.boosts.join(', ')}`;
+}
+
+handleTripFinish(user, channelID, str, undefined, data, loot);
+}
+};

--- a/src/testing/minionStatusRaw.ts
+++ b/src/testing/minionStatusRaw.ts
@@ -17,8 +17,9 @@ import type {
 	ColoTaskOptions,
 	CookingActivityTaskOptions,
 	CraftingActivityTaskOptions,
-	FiremakingActivityTaskOptions,
-	FishingActivityTaskOptions,
+        FiremakingActivityTaskOptions,
+        FishingActivityTaskOptions,
+        BarbloreActivityTaskOptions,
 	FletchingActivityTaskOptions,
 	GroupMonsterActivityTaskOptions,
 	InfernoOptions,
@@ -61,11 +62,21 @@ export function minionStatusRaw(task: ActivityTaskData): string {
 			const item = Crafting.Craftables.find(i => i.id === data.craftableID);
 			return `Crafted ${data.quantity}x ${item?.name} in ${d}`;
 		}
-		case 'Fishing': {
-			const data = task as FishingActivityTaskOptions;
-			const fish = Fishing.Fishes.find(i => i.id === data.fishID);
-			return `Fished ${data.quantity}x ${fish?.name} in ${d}`;
-		}
+                case 'Fishing': {
+                        const data = task as FishingActivityTaskOptions;
+                        const fish = Fishing.Fishes.find(i => i.id === data.fishID);
+                        return `Fished ${data.quantity}x ${fish?.name} in ${d}`;
+                }
+                case 'BarbloreFishing': {
+                        const data = task as BarbloreActivityTaskOptions;
+                        const fish = Fishing.Fishes.find(i => i.id === data.fishID);
+                        const mixes = data.mixPlan
+                                .filter(plan => plan.quantity > 0)
+                                .map(plan => `${plan.quantity.toLocaleString()}x ${plan.mixName}`)
+                                .join(', ');
+                        const mixPart = mixes.length > 0 ? ` and mixed ${mixes}` : '';
+                        return `Barblore fished ${data.quantity}x ${fish?.name}${mixPart} in ${d}`;
+                }
 		case 'Mining': {
 			const data = task as MiningActivityTaskOptions;
 			const ore = Mining.Ores.find(i => i.id === data.oreID);


### PR DESCRIPTION
## Summary
- add a Barblore flag to the /fish command and dispatch a dedicated activity type
- implement Barblore trip planning, costing, and activity handling for multi-skill XP and loot
- wire up repeat, status, documentation, and Prisma schema updates for the new activity