### PR TITLE
Add Bones to peaches to MTA rewards

### DIFF
--- a/src/lib/data/CollectionsExport.ts
+++ b/src/lib/data/CollectionsExport.ts
@@ -1253,9 +1253,8 @@ export const magicTrainingArenaCL = resolveItems([
 	'Infinity bottoms',
 	'Infinity boots',
 	'Infinity gloves',
-	"Mage's book"
-	// We cant unlock this spell
-	// 'Bones to peaches'
+	"Mage's book",
+	'Bones to peaches'
 ]);
 export const mahoganyHomesCL = resolveItems([
 	'Builders supply crate',

--- a/src/mahoji/lib/abstracted_commands/mageTrainingArenaCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/mageTrainingArenaCommand.ts
@@ -60,6 +60,10 @@ export const mageTrainingArenaBuyables = [
 	{
 		item: getOSItem("Mage's book"),
 		cost: 1260
+	},
+	{
+		item: getOSItem('Bones to peaches'),
+		cost: 900
 	}
 ];
 

--- a/tests/unit/snapshots/clsnapshots.test.ts.snap
+++ b/tests/unit/snapshots/clsnapshots.test.ts.snap
@@ -63,7 +63,7 @@ Kraken (4)
 Kree'arra (8)
 Last Man Standing (32)
 Leagues (28)
-Magic Training Arena (10)
+Magic Training Arena (11)
 Mahogany Homes (8)
 Master Treasure Trail Rewards (Rare) (45)
 Master Treasure Trails (49)
@@ -482,6 +482,7 @@ Bob's green shirt
 Bob's purple shirt
 Bob's red shirt
 Bolt rack
+Bones to peaches
 Boots of darkness
 Boots of the eye
 Bottom of sceptre


### PR DESCRIPTION
## Summary
- add Bones to peaches to the Magic Training Arena collection log export
- allow Bones to peaches to be purchased from the mage training arena shop using a combined 900 point cost
- refresh the collection log snapshot to cover the new reward slot

## Testing
- pnpm vitest run --config vitest.unit.config.mts tests/unit/clsnapshots.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cac7e31400832698146cbe8e8cadb5