### PR TITLE
Allow commands to override zero-time throughput

### DIFF
--- a/src/lib/types/minions.ts
+++ b/src/lib/types/minions.ts
@@ -122,6 +122,10 @@ export interface AgilityActivityTaskOptions extends ActivityTaskOptions {
 		itemID: number;
 		quantity: number;
 	} | null;
+	fletch?: {
+		id: number;
+		qty: number;
+	} | null;
 }
 
 export interface CookingActivityTaskOptions extends ActivityTaskOptions {
@@ -408,6 +412,10 @@ export interface SepulchreActivityTaskOptions extends MinigameActivityTaskOption
 		id: number;
 		qty: number;
 	};
+	alch?: {
+		itemID: number;
+		quantity: number;
+	} | null;
 }
 
 export interface PlunderActivityTaskOptions extends MinigameActivityTaskOptions {

--- a/src/lib/util/minionStatus.ts
+++ b/src/lib/util/minionStatus.ts
@@ -132,8 +132,26 @@ export function minionStatus(user: MUser) {
 			const data = currentTask as AgilityActivityTaskOptions;
 
 			const course = Agility.Courses.find(course => course.id === data.courseID);
+			const zeroTimeParts: string[] = [];
 
-			return `${name} is currently running ${data.quantity}x ${course?.name} laps. ${formattedDuration} Your ${
+			if (data.fletch) {
+				const fletchable = zeroTimeFletchables.find(item => item.id === data.fletch!.id);
+				if (fletchable) {
+					const setsText = fletchable.outputMultiple ? ' sets of' : '';
+					zeroTimeParts.push(`They are also fletching ${data.fletch!.qty}${setsText} ${fletchable.name}.`);
+				}
+			}
+
+			if (data.alch) {
+				const alchItem = Items.get(data.alch.itemID);
+				if (alchItem) {
+					zeroTimeParts.push(`They are also alching ${data.alch.quantity}x ${alchItem.name}.`);
+				}
+			}
+
+			const zeroTimeSuffix = zeroTimeParts.length > 0 ? ` ${zeroTimeParts.join(' ')}` : '';
+
+			return `${name} is currently running ${data.quantity}x ${course?.name} laps.${zeroTimeSuffix} ${formattedDuration} Your ${
 				Emoji.Agility
 			} Agility level is ${user.skillLevel(SkillsEnum.Agility)}`;
 		}
@@ -397,10 +415,22 @@ export function minionStatus(user: MUser) {
 			const data = currentTask as SepulchreActivityTaskOptions;
 
 			const fletchable = data.fletch ? zeroTimeFletchables.find(i => i.id === data.fletch!.id) : null;
+			const parts: string[] = [];
 
-			const fletchingPart = fletchable ? `They are also fletching ${data.fletch!.qty}x ${fletchable.name}. ` : '';
+			if (fletchable) {
+				parts.push(`They are also fletching ${data.fletch!.qty}x ${fletchable.name}.`);
+			}
 
-			return `${name} is currently doing ${data.quantity}x laps of the Hallowed Sepulchre. ${fletchingPart}${formattedDuration}`;
+			if (data.alch) {
+				const alchItem = Items.get(data.alch.itemID);
+				if (alchItem) {
+					parts.push(`They are also alching ${data.alch.quantity}x ${alchItem.name}.`);
+				}
+			}
+
+			const zeroTimeInfo = parts.length > 0 ? ` ${parts.join(' ')}` : '';
+
+			return `${name} is currently doing ${data.quantity}x laps of the Hallowed Sepulchre.${zeroTimeInfo} ${formattedDuration}`;
 		}
 
 		case 'Plunder': {

--- a/src/lib/util/zeroTimeActivity.ts
+++ b/src/lib/util/zeroTimeActivity.ts
@@ -41,23 +41,23 @@ export type ZeroTimeActivityResult =
 	  };
 
 export interface ZeroTimeActivityResponse {
-        result: ZeroTimeActivityResult | null;
-        message?: string;
+	result: ZeroTimeActivityResult | null;
+	message?: string;
 }
 
 interface BaseAttemptZeroTimeActivityOptions {
-        user: MUser;
-        duration: number;
-        quantityOverride?: number;
-        itemsPerHour?: number;
+	user: MUser;
+	duration: number;
+	quantityOverride?: number;
+	itemsPerHour?: number;
 }
 
 type AttemptZeroTimeActivityOptions =
-        | (BaseAttemptZeroTimeActivityOptions & {
-                        type: 'alch';
-                        variant?: 'agility' | 'default';
-          })
-        | (BaseAttemptZeroTimeActivityOptions & { type: 'fletch' });
+	| (BaseAttemptZeroTimeActivityOptions & {
+			type: 'alch';
+			variant?: 'agility' | 'default';
+	  })
+	| (BaseAttemptZeroTimeActivityOptions & { type: 'fletch' });
 
 export function getZeroTimeActivitySettings(user: MUser): ZeroTimeActivitySettings | null {
 	const type = user.user.zero_time_activity_type;
@@ -89,11 +89,11 @@ function resolveZeroTimeFletchable(settings: ZeroTimeActivitySettings | null): F
 }
 
 export function getZeroTimeFletchTime(fletchable: Fletchable): number | null {
-        const mapping: { types: (Fletchable | Fletchable[])[]; time: number }[] = [
-                { types: [Darts, Bolts, BroadBolts], time: Time.Second * 0.2 },
-                {
-                        types: [Arrows, BroadArrows, Javelins, TippedBolts, TippedDragonBolts, AmethystBroadBolts],
-                        time: Time.Second * 0.36
+	const mapping: { types: (Fletchable | Fletchable[])[]; time: number }[] = [
+		{ types: [Darts, Bolts, BroadBolts], time: Time.Second * 0.2 },
+		{
+			types: [Arrows, BroadArrows, Javelins, TippedBolts, TippedDragonBolts, AmethystBroadBolts],
+			time: Time.Second * 0.36
 		}
 	];
 	for (const { types, time } of mapping) {
@@ -105,18 +105,18 @@ export function getZeroTimeFletchTime(fletchable: Fletchable): number | null {
 }
 
 function calculateAlching(
-        options: Extract<AttemptZeroTimeActivityOptions, { type: 'alch' }>,
-        settings: ZeroTimeActivitySettings | null
+	options: Extract<AttemptZeroTimeActivityOptions, { type: 'alch' }>,
+	settings: ZeroTimeActivitySettings | null
 ): ZeroTimeActivityResponse {
-        const { user, duration, itemsPerHour, quantityOverride } = options;
-        const variant = options.variant ?? 'default';
+	const { user, duration, itemsPerHour, quantityOverride } = options;
+	const variant = options.variant ?? 'default';
 
-        if (user.skillLevel('magic') < 55) {
-                return { result: null, message: 'You need level 55 Magic to perform zero time alching.' };
-        }
+	if (user.skillLevel('magic') < 55) {
+		return { result: null, message: 'You need level 55 Magic to perform zero time alching.' };
+	}
 
-        const itemFromSettings = resolveConfiguredAlchItem(settings);
-        const durationPerCast = variant === 'agility' ? timePerAlchAgility : timePerAlch;
+	const itemFromSettings = resolveConfiguredAlchItem(settings);
+	const durationPerCast = variant === 'agility' ? timePerAlchAgility : timePerAlch;
 
 	let itemToAlch: Item | null = itemFromSettings;
 	if (!itemToAlch) {
@@ -144,35 +144,35 @@ function calculateAlching(
 		};
 	}
 
-        const fireRunes = bank.amount('Fire rune');
-        const hasInfiniteFire = user.hasEquipped(unlimitedFireRuneProviders);
+	const fireRunes = bank.amount('Fire rune');
+	const hasInfiniteFire = user.hasEquipped(unlimitedFireRuneProviders);
 
-        const overrideUsed = quantityOverride !== undefined || itemsPerHour !== undefined;
+	const overrideUsed = quantityOverride !== undefined || itemsPerHour !== undefined;
 
-        let desiredQuantity: number;
-        if (quantityOverride !== undefined) {
-                desiredQuantity = Math.floor(quantityOverride);
-        } else if (itemsPerHour !== undefined) {
-                desiredQuantity = Math.floor((itemsPerHour * duration) / Time.Hour);
-        } else {
-                desiredQuantity = Math.floor(duration / durationPerCast);
-        }
+	let desiredQuantity: number;
+	if (quantityOverride !== undefined) {
+		desiredQuantity = Math.floor(quantityOverride);
+	} else if (itemsPerHour !== undefined) {
+		desiredQuantity = Math.floor((itemsPerHour * duration) / Time.Hour);
+	} else {
+		desiredQuantity = Math.floor(duration / durationPerCast);
+	}
 
-        if (desiredQuantity <= 0) {
-                if (!overrideUsed) {
-                        return {
-                                result: null,
-                                message: `You're missing resources to alch ${itemToAlch.name}.`
-                        };
-                }
-                return { result: null };
-        }
+	if (desiredQuantity <= 0) {
+		if (!overrideUsed) {
+			return {
+				result: null,
+				message: `You're missing resources to alch ${itemToAlch.name}.`
+			};
+		}
+		return { result: null };
+	}
 
-        let maxCasts = Math.min(desiredQuantity, alchItemQty, natureRunes);
-        if (!hasInfiniteFire) {
-                maxCasts = Math.min(maxCasts, Math.floor(fireRunes / 5));
-        }
-        maxCasts = Math.floor(maxCasts);
+	let maxCasts = Math.min(desiredQuantity, alchItemQty, natureRunes);
+	if (!hasInfiniteFire) {
+		maxCasts = Math.min(maxCasts, Math.floor(fireRunes / 5));
+	}
+	maxCasts = Math.floor(maxCasts);
 
 	if (maxCasts <= 0) {
 		return {
@@ -193,28 +193,28 @@ function calculateAlching(
 		};
 	}
 
-        const alchGP = (itemToAlch.highalch ?? 0) * maxCasts;
-        const bankToAdd = new Bank().add('Coins', alchGP);
-        const timePerAction = overrideUsed ? duration / maxCasts : durationPerCast;
+	const alchGP = (itemToAlch.highalch ?? 0) * maxCasts;
+	const bankToAdd = new Bank().add('Coins', alchGP);
+	const timePerAction = overrideUsed ? duration / maxCasts : durationPerCast;
 
-        return {
-                result: {
-                        type: 'alch',
-                        item: itemToAlch,
-                        quantity: maxCasts,
-                        bankToRemove,
-                        bankToAdd,
-                        timePerAction
-                }
-        };
+	return {
+		result: {
+			type: 'alch',
+			item: itemToAlch,
+			quantity: maxCasts,
+			bankToRemove,
+			bankToAdd,
+			timePerAction
+		}
+	};
 }
 
 function calculateFletching(
-        options: Extract<AttemptZeroTimeActivityOptions, { type: 'fletch' }>,
-        settings: ZeroTimeActivitySettings | null
+	options: Extract<AttemptZeroTimeActivityOptions, { type: 'fletch' }>,
+	settings: ZeroTimeActivitySettings | null
 ): ZeroTimeActivityResponse {
-        const { user, duration, itemsPerHour, quantityOverride } = options;
-        const fletchable = resolveZeroTimeFletchable(settings);
+	const { user, duration, itemsPerHour, quantityOverride } = options;
+	const fletchable = resolveZeroTimeFletchable(settings);
 	if (!fletchable) {
 		if (settings?.type === 'fletch') {
 			return {
@@ -246,7 +246,7 @@ function calculateFletching(
 		}
 	}
 
-        const timePerItem = getZeroTimeFletchTime(fletchable);
+	const timePerItem = getZeroTimeFletchTime(fletchable);
 	if (!timePerItem) {
 		return {
 			result: null,
@@ -254,66 +254,66 @@ function calculateFletching(
 		};
 	}
 
-        const overrideUsed = quantityOverride !== undefined || itemsPerHour !== undefined;
-        const outputMultiple = fletchable.outputMultiple ?? 1;
+	const overrideUsed = quantityOverride !== undefined || itemsPerHour !== undefined;
+	const outputMultiple = fletchable.outputMultiple ?? 1;
 
-        let desiredQuantity: number;
-        if (quantityOverride !== undefined) {
-                desiredQuantity = Math.floor(quantityOverride);
-        } else if (itemsPerHour !== undefined) {
-                desiredQuantity = Math.floor((itemsPerHour * duration) / Time.Hour / outputMultiple);
-        } else {
-                desiredQuantity = Math.floor(duration / timePerItem);
-        }
+	let desiredQuantity: number;
+	if (quantityOverride !== undefined) {
+		desiredQuantity = Math.floor(quantityOverride);
+	} else if (itemsPerHour !== undefined) {
+		desiredQuantity = Math.floor((itemsPerHour * duration) / Time.Hour / outputMultiple);
+	} else {
+		desiredQuantity = Math.floor(duration / timePerItem);
+	}
 
-        if (desiredQuantity <= 0) {
-                return { result: null };
-        }
+	if (desiredQuantity <= 0) {
+		return { result: null };
+	}
 
-        const maxSets = user.bank.fits(fletchable.inputItems);
-        if (maxSets === 0) {
-                return {
-                        result: null,
-                        message: `You don't have the supplies required to fletch ${fletchable.name}.`
-                };
-        }
-        const quantity = Math.min(desiredQuantity, maxSets);
+	const maxSets = user.bank.fits(fletchable.inputItems);
+	if (maxSets === 0) {
+		return {
+			result: null,
+			message: `You don't have the supplies required to fletch ${fletchable.name}.`
+		};
+	}
+	const quantity = Math.min(desiredQuantity, maxSets);
 
-        if (quantity <= 0) {
-                return {
-                        result: null,
-                        message: `You don't have the supplies required to fletch ${fletchable.name}.`
-                };
-        }
+	if (quantity <= 0) {
+		return {
+			result: null,
+			message: `You don't have the supplies required to fletch ${fletchable.name}.`
+		};
+	}
 
-        const itemsNeeded = fletchable.inputItems.clone().multiply(quantity);
-        if (!user.bankWithGP.has(itemsNeeded)) {
-                return {
-                        result: null,
+	const itemsNeeded = fletchable.inputItems.clone().multiply(quantity);
+	if (!user.bankWithGP.has(itemsNeeded)) {
+		return {
+			result: null,
 			message: `You don't have the supplies required to fletch ${fletchable.name}.`
 		};
 	}
 
 	return {
-                result: {
-                        type: 'fletch',
-                        fletchable,
-                        quantity,
-                        itemsToRemove: itemsNeeded,
-                        timePerAction: overrideUsed ? duration / quantity : timePerItem
-                }
-        };
+		result: {
+			type: 'fletch',
+			fletchable,
+			quantity,
+			itemsToRemove: itemsNeeded,
+			timePerAction: overrideUsed ? duration / quantity : timePerItem
+		}
+	};
 }
 
 export function attemptZeroTimeActivity(options: AttemptZeroTimeActivityOptions): ZeroTimeActivityResponse {
-        const settings = getZeroTimeActivitySettings(options.user);
-        if (!settings || settings.type !== options.type) {
-                return { result: null };
-        }
+	const settings = getZeroTimeActivitySettings(options.user);
+	if (!settings || settings.type !== options.type) {
+		return { result: null };
+	}
 
-        if (options.type === 'alch') {
-                return calculateAlching(options, settings);
-        }
+	if (options.type === 'alch') {
+		return calculateAlching(options, settings);
+	}
 
-        return calculateFletching(options, settings);
+	return calculateFletching(options, settings);
 }

--- a/src/mahoji/commands/laps.ts
+++ b/src/mahoji/commands/laps.ts
@@ -3,6 +3,7 @@ import { type CommandRunOptions, formatDuration, stringMatches } from '@oldschoo
 import { ApplicationCommandOptionType, bold } from 'discord.js';
 
 import { type ZeroTimeActivityResult, attemptZeroTimeActivity } from '@/lib/util/zeroTimeActivity';
+import { timePerAlchAgility } from '@/mahoji/lib/abstracted_commands/alchCommand';
 import { quests } from '../../lib/minions/data/quests';
 import { courses } from '../../lib/skilling/skills/agility';
 import type { AgilityActivityTaskOptions } from '../../lib/types/minions';
@@ -90,21 +91,23 @@ export const lapsCommand: OSBMahojiCommand = {
 			)}.`;
 		}
 
-		let response = `${user.minionName} is now doing ${quantity}x ${
-			course.name
-		} laps, it'll take around ${formatDuration(duration)} to finish.`;
+                let response = `${user.minionName} is now doing ${quantity}x ${
+                        course.name
+                } laps, it'll take around ${formatDuration(duration)} to finish.`;
 
-		type AlchResult = Extract<ZeroTimeActivityResult, { type: 'alch' }>;
+                type AlchResult = Extract<ZeroTimeActivityResult, { type: 'alch' }>;
 		let alchResult: AlchResult | null = null;
 		let zeroTimeMessage: string | undefined;
 
-		if (course.name !== 'Ape Atoll Agility Course') {
-			const zeroTime = attemptZeroTimeActivity({
-				type: 'alch',
-				user,
-				duration,
-				variant: 'agility'
-			});
+                if (course.name !== 'Ape Atoll Agility Course') {
+                        const itemsPerHour = Time.Hour / timePerAlchAgility;
+                        const zeroTime = attemptZeroTimeActivity({
+                                type: 'alch',
+                                user,
+                                duration,
+                                variant: 'agility',
+                                itemsPerHour
+                        });
 
 			if (zeroTime.result?.type === 'alch') {
 				alchResult = zeroTime.result;

--- a/tests/unit/zeroTimeActivity.test.ts
+++ b/tests/unit/zeroTimeActivity.test.ts
@@ -8,11 +8,11 @@ import { timePerAlch } from '../../src/mahoji/lib/abstracted_commands/alchComman
 import { mockMUser } from './userutil';
 
 describe('attemptZeroTimeActivity', () => {
-        test('alching success', () => {
-                const item = Items.getOrThrow('Yew longbow');
-                const duration = timePerAlch * 50;
-                const user = mockMUser({
-                        bank: new Bank().add('Nature rune', 200).add('Fire rune', 500).add(item.id, 200),
+	test('alching success', () => {
+		const item = Items.getOrThrow('Yew longbow');
+		const duration = timePerAlch * 50;
+		const user = mockMUser({
+			bank: new Bank().add('Nature rune', 200).add('Fire rune', 500).add(item.id, 200),
 			skills_magic: convertLVLtoXP(70),
 			zero_time_activity_type: 'alch',
 			zero_time_activity_item: item.id
@@ -33,37 +33,37 @@ describe('attemptZeroTimeActivity', () => {
 		const expectedRemove = new Bank().add('Nature rune', 50).add('Fire rune', 250).add(item.id, 50);
 		expect(response.result.bankToRemove.equals(expectedRemove)).toBe(true);
 		expect(response.result.bankToAdd.equals(new Bank().add('Coins', (item.highalch ?? 0) * 50))).toBe(true);
-                expect(response.result.timePerAction).toBe(timePerAlch);
-        });
+		expect(response.result.timePerAction).toBe(timePerAlch);
+	});
 
-        test('alching override respects items per hour', () => {
-                const item = Items.getOrThrow('Yew longbow');
-                const duration = Time.Hour;
-                const ratePerHour = 1000;
-                const user = mockMUser({
-                        bank: new Bank()
-                                .add('Nature rune', ratePerHour * 2)
-                                .add('Fire rune', ratePerHour * 10)
-                                .add(item.id, ratePerHour * 2),
-                        skills_magic: convertLVLtoXP(70),
-                        zero_time_activity_type: 'alch',
-                        zero_time_activity_item: item.id
-                });
+	test('alching override respects items per hour', () => {
+		const item = Items.getOrThrow('Yew longbow');
+		const duration = Time.Hour;
+		const ratePerHour = 1000;
+		const user = mockMUser({
+			bank: new Bank()
+				.add('Nature rune', ratePerHour * 2)
+				.add('Fire rune', ratePerHour * 10)
+				.add(item.id, ratePerHour * 2),
+			skills_magic: convertLVLtoXP(70),
+			zero_time_activity_type: 'alch',
+			zero_time_activity_item: item.id
+		});
 
-                const response = attemptZeroTimeActivity({
-                        type: 'alch',
-                        user,
-                        duration,
-                        variant: 'default',
-                        itemsPerHour: ratePerHour
-                });
+		const response = attemptZeroTimeActivity({
+			type: 'alch',
+			user,
+			duration,
+			variant: 'default',
+			itemsPerHour: ratePerHour
+		});
 
-                expect(response.result?.type).toBe('alch');
-                if (!response.result || response.result.type !== 'alch') return;
+		expect(response.result?.type).toBe('alch');
+		if (!response.result || response.result.type !== 'alch') return;
 
-                expect(response.result.quantity).toBe(ratePerHour);
-                expect(response.result.timePerAction).toBe(duration / ratePerHour);
-        });
+		expect(response.result.quantity).toBe(ratePerHour);
+		expect(response.result.timePerAction).toBe(duration / ratePerHour);
+	});
 
 	test('alching failure when missing runes', () => {
 		const item = Items.getOrThrow('Yew longbow');
@@ -85,10 +85,10 @@ describe('attemptZeroTimeActivity', () => {
 		expect(response.message).toBe("You're missing resources to alch Yew longbow.");
 	});
 
-        test('fletching success', () => {
-                const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
-                expect(fletchable).toBeDefined();
-                if (!fletchable) return;
+	test('fletching success', () => {
+		const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
+		expect(fletchable).toBeDefined();
+		if (!fletchable) return;
 
 		const duration = Time.Second * 40;
 		const user = mockMUser({
@@ -111,39 +111,39 @@ describe('attemptZeroTimeActivity', () => {
 		expect(response.result.quantity).toBe(200);
 		const expectedRemove = fletchable.inputItems.clone().multiply(200);
 		expect(response.result.itemsToRemove.equals(expectedRemove)).toBe(true);
-                expect(response.result.timePerAction).toBeCloseTo(Time.Second * 0.2, 5);
-        });
+		expect(response.result.timePerAction).toBeCloseTo(Time.Second * 0.2, 5);
+	});
 
-        test('fletching override uses item rate', () => {
-                const fletchable = zeroTimeFletchables.find(item => item.name === 'Wolfbone arrowtips');
-                expect(fletchable).toBeDefined();
-                if (!fletchable) return;
+	test('fletching override uses item rate', () => {
+		const fletchable = zeroTimeFletchables.find(item => item.name === 'Wolfbone arrowtips');
+		expect(fletchable).toBeDefined();
+		if (!fletchable) return;
 
-                const duration = Time.Hour;
-                const itemsPerHour = 12_000;
-                const outputMultiple = fletchable.outputMultiple ?? 1;
-                const expectedSets = Math.floor((itemsPerHour * duration) / Time.Hour / outputMultiple);
-                const user = mockMUser({
-                        bank: new Bank().add('Wolf bones', expectedSets * 2),
-                        skills_fletching: convertLVLtoXP(70),
-                        zero_time_activity_type: 'fletch',
-                        zero_time_activity_item: fletchable.id
-                });
+		const duration = Time.Hour;
+		const itemsPerHour = 12_000;
+		const outputMultiple = fletchable.outputMultiple ?? 1;
+		const expectedSets = Math.floor((itemsPerHour * duration) / Time.Hour / outputMultiple);
+		const user = mockMUser({
+			bank: new Bank().add('Wolf bones', expectedSets * 2),
+			skills_fletching: convertLVLtoXP(70),
+			zero_time_activity_type: 'fletch',
+			zero_time_activity_item: fletchable.id
+		});
 
-                const response = attemptZeroTimeActivity({
-                        type: 'fletch',
-                        user,
-                        duration,
-                        itemsPerHour
-                });
+		const response = attemptZeroTimeActivity({
+			type: 'fletch',
+			user,
+			duration,
+			itemsPerHour
+		});
 
-                expect(response.result?.type).toBe('fletch');
-                if (!response.result || response.result.type !== 'fletch') return;
+		expect(response.result?.type).toBe('fletch');
+		if (!response.result || response.result.type !== 'fletch') return;
 
-                expect(response.result.quantity).toBe(expectedSets);
-                expect(response.result.itemsToRemove.amount('Wolf bones')).toBe(expectedSets);
-                expect(response.result.timePerAction).toBeCloseTo(duration / expectedSets, 5);
-        });
+		expect(response.result.quantity).toBe(expectedSets);
+		expect(response.result.itemsToRemove.amount('Wolf bones')).toBe(expectedSets);
+		expect(response.result.timePerAction).toBeCloseTo(duration / expectedSets, 5);
+	});
 
 	test('fletching failure without slayer unlock', () => {
 		const fletchable = zeroTimeFletchables.find(item => item.name === 'Broad arrows');

--- a/tests/unit/zeroTimeActivity.test.ts
+++ b/tests/unit/zeroTimeActivity.test.ts
@@ -8,11 +8,11 @@ import { timePerAlch } from '../../src/mahoji/lib/abstracted_commands/alchComman
 import { mockMUser } from './userutil';
 
 describe('attemptZeroTimeActivity', () => {
-	test('alching success', () => {
-		const item = Items.getOrThrow('Yew longbow');
-		const duration = timePerAlch * 50;
-		const user = mockMUser({
-			bank: new Bank().add('Nature rune', 200).add('Fire rune', 500).add(item.id, 200),
+        test('alching success', () => {
+                const item = Items.getOrThrow('Yew longbow');
+                const duration = timePerAlch * 50;
+                const user = mockMUser({
+                        bank: new Bank().add('Nature rune', 200).add('Fire rune', 500).add(item.id, 200),
 			skills_magic: convertLVLtoXP(70),
 			zero_time_activity_type: 'alch',
 			zero_time_activity_item: item.id
@@ -33,8 +33,37 @@ describe('attemptZeroTimeActivity', () => {
 		const expectedRemove = new Bank().add('Nature rune', 50).add('Fire rune', 250).add(item.id, 50);
 		expect(response.result.bankToRemove.equals(expectedRemove)).toBe(true);
 		expect(response.result.bankToAdd.equals(new Bank().add('Coins', (item.highalch ?? 0) * 50))).toBe(true);
-		expect(response.result.timePerAction).toBe(timePerAlch);
-	});
+                expect(response.result.timePerAction).toBe(timePerAlch);
+        });
+
+        test('alching override respects items per hour', () => {
+                const item = Items.getOrThrow('Yew longbow');
+                const duration = Time.Hour;
+                const ratePerHour = 1000;
+                const user = mockMUser({
+                        bank: new Bank()
+                                .add('Nature rune', ratePerHour * 2)
+                                .add('Fire rune', ratePerHour * 10)
+                                .add(item.id, ratePerHour * 2),
+                        skills_magic: convertLVLtoXP(70),
+                        zero_time_activity_type: 'alch',
+                        zero_time_activity_item: item.id
+                });
+
+                const response = attemptZeroTimeActivity({
+                        type: 'alch',
+                        user,
+                        duration,
+                        variant: 'default',
+                        itemsPerHour: ratePerHour
+                });
+
+                expect(response.result?.type).toBe('alch');
+                if (!response.result || response.result.type !== 'alch') return;
+
+                expect(response.result.quantity).toBe(ratePerHour);
+                expect(response.result.timePerAction).toBe(duration / ratePerHour);
+        });
 
 	test('alching failure when missing runes', () => {
 		const item = Items.getOrThrow('Yew longbow');
@@ -56,10 +85,10 @@ describe('attemptZeroTimeActivity', () => {
 		expect(response.message).toBe("You're missing resources to alch Yew longbow.");
 	});
 
-	test('fletching success', () => {
-		const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
-		expect(fletchable).toBeDefined();
-		if (!fletchable) return;
+        test('fletching success', () => {
+                const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
+                expect(fletchable).toBeDefined();
+                if (!fletchable) return;
 
 		const duration = Time.Second * 40;
 		const user = mockMUser({
@@ -82,8 +111,39 @@ describe('attemptZeroTimeActivity', () => {
 		expect(response.result.quantity).toBe(200);
 		const expectedRemove = fletchable.inputItems.clone().multiply(200);
 		expect(response.result.itemsToRemove.equals(expectedRemove)).toBe(true);
-		expect(response.result.timePerAction).toBeCloseTo(Time.Second * 0.2, 5);
-	});
+                expect(response.result.timePerAction).toBeCloseTo(Time.Second * 0.2, 5);
+        });
+
+        test('fletching override uses item rate', () => {
+                const fletchable = zeroTimeFletchables.find(item => item.name === 'Wolfbone arrowtips');
+                expect(fletchable).toBeDefined();
+                if (!fletchable) return;
+
+                const duration = Time.Hour;
+                const itemsPerHour = 12_000;
+                const outputMultiple = fletchable.outputMultiple ?? 1;
+                const expectedSets = Math.floor((itemsPerHour * duration) / Time.Hour / outputMultiple);
+                const user = mockMUser({
+                        bank: new Bank().add('Wolf bones', expectedSets * 2),
+                        skills_fletching: convertLVLtoXP(70),
+                        zero_time_activity_type: 'fletch',
+                        zero_time_activity_item: fletchable.id
+                });
+
+                const response = attemptZeroTimeActivity({
+                        type: 'fletch',
+                        user,
+                        duration,
+                        itemsPerHour
+                });
+
+                expect(response.result?.type).toBe('fletch');
+                if (!response.result || response.result.type !== 'fletch') return;
+
+                expect(response.result.quantity).toBe(expectedSets);
+                expect(response.result.itemsToRemove.amount('Wolf bones')).toBe(expectedSets);
+                expect(response.result.timePerAction).toBeCloseTo(duration / expectedSets, 5);
+        });
 
 	test('fletching failure without slayer unlock', () => {
 		const fletchable = zeroTimeFletchables.find(item => item.name === 'Broad arrows');


### PR DESCRIPTION
## Summary
- allow zero-time alching and fletching calculations to accept per-hour or quantity overrides while keeping time-per-action in sync with the chosen rate
- expose the zero-time fletching speed helper and use it in Sepulchre so the command now decides the per-hour throughput it wants to use
- pass the agility alching rate from the laps command and add coverage for the new override paths

## Testing
- `pnpm vitest run --config vitest.unit.config.mts tests/unit/zeroTimeActivity.test.ts` *(fails: missing oldschooljs package entry in Vitest environment)*