### PR TITLE
Fix Sepulchre alch item lookup type

### DIFF
--- a/src/tasks/minions/minigames/sepulchreActivity.ts
+++ b/src/tasks/minions/minigames/sepulchreActivity.ts
@@ -62,7 +62,7 @@ export const sepulchreTask: MinionTask = {
 
 			if (alch && alch.quantity > 0) {
 				alchQuantity = alch.quantity;
-				alchItem = Items.get(alch.itemID);
+                                alchItem = Items.get(alch.itemID) ?? null;
 
 				if (!alchItem || !alchItem.highalch) {
 					throw new Error(`Alch item id ${alch.itemID} not valid for Sepulchre alching.`);


### PR DESCRIPTION
## Summary
- ensure Sepulchre alching item lookup falls back to null instead of undefined

## Testing
- pnpm test:types *(fails: pre-existing TypeScript errors about Prisma client definitions and implicit any usage)*