### PR TITLE
Document zero-time activities in dedicated guide

### DIFF
--- a/docs/src/content/docs/osb/Activities/hallowed-sepulchre.md
+++ b/docs/src/content/docs/osb/Activities/hallowed-sepulchre.md
@@ -30,13 +30,14 @@ Most of the boosts come from items purchased from the shop.
 
 **Note:** The [[Hallowed ring]] from the shop does **not** provide a boost or benefit.
 
-## Fletching While Running
+## Zero-time Alching and Fletching
 
-You can fletch specific "zero-time" items during each lap by specifying the `fletching:` option when starting a run:
+See the [Zero-time Activities guide](/osb/miscellaneous/zero-time-activities) for full configuration steps. When you're ready to start [[/minigames sepulchre start]], set things up beforehand so each floor automatically triggers the background action you prefer.
 
-- [[/minigames sepulchre start fletching\:Rune dart]]
+- Zero-time alching inside the Sepulchre performs roughly 1,000 casts per hour.
+- Zero-time fletching uses each item's standard zero-time rate (around 18,000 sets/hour for darts and bolts, ~10,000 for arrows, javelins, tipped bolts, and similar ammunition).
 
-This works with darts, arrows, bolts, broad arrows, broad bolts, amethyst broad bolts, tipped bolts, tipped dragon bolts, and javelins. The necessary materials are removed from your bank and do not extend the trip duration.
+All casts or fletched items happen between obstacles without delaying your run. Leave the alch item unset if you want the bot to choose from your favourite alchs on every trip.
 
 ## Hallowed Sepulchre Shop
 

--- a/docs/src/content/docs/osb/Miscellaneous/zero-time-activities.md
+++ b/docs/src/content/docs/osb/Miscellaneous/zero-time-activities.md
@@ -1,0 +1,40 @@
+---
+title: "Zero-time Activities"
+---
+
+Zero-time activities let your minion cast High Alchemy or fletch stackable ammunition during trips without increasing the trip's duration. Configure them with [[/zero_time_activity]] before you start Agility laps, the Hallowed Sepulchre, or any other activity that supports zero-time actions.
+
+## Configuring `/zero_time_activity`
+
+1. Choose your background action with [[/zero_time_activity type\:alch]] or [[/zero_time_activity type\:fletch]].
+2. If you select `fletch`, provide the exact item with [[/zero_time_activity type\:fletch item\:"Rune dart"]] (autocomplete suggests every supported choice).
+3. For `alch`, leave the item blank to let the bot automatically pick from your favourite alchs each trip, or specify a particular item such as [[/zero_time_activity type\:alch item\:"Yew longbow"]].
+4. Update your favourite alch list with [[/config user favorite_alchs add\:Rune platebody]] so automatic selection has options to choose from.
+5. Use [[/zero_time_activity clear\:true]] to remove the configuration.
+
+Only one zero-time activity can run per trip. Switching between alching and fletching requires re-running `/zero_time_activity`. The necessary runes or fletching materials are removed from your bank when the trip starts, and zero-time actions never extend the duration of the main activity.
+
+## Zero-time Alching
+
+- Requires level 55 Magic and the materials for High Alchemy (or the Rune Pouch setup you normally use).
+- Leaving the item unset makes the bot choose from your favourite alchs at the start of **every** trip, so you always alch profitable or priority items.
+- Casting rates depend on the host activity:
+  - **Agility laps:** roughly 277 casts per hour.
+  - **Hallowed Sepulchre:** roughly 1,000 casts per hour.
+- All casts happen in the background, so you can keep running laps or floor rotations without interruption.
+
+## Zero-time Fletching
+
+- Works with darts, arrows, javelins, bolts, tipped bolts, tipped dragon bolts, broad ammunition, and any other stackable fletching product that appears in the autocomplete list.
+- You must meet the item's Fletching level requirement and own any necessary Slayer unlocks before configuring it.
+- Fletching speeds vary by content:
+  - **Agility laps:** up to ~15,000 items per hour for darts, bolts, broad bolts, and similar stackables.
+  - **Hallowed Sepulchre:** uses the item's zero-time rate (about 18,000 sets/hour for darts and bolts, ~10,000 sets/hour for arrows, javelins, and other ammunition).
+- Materials (tips, feathers, unfinished ammunition, etc.) are removed when the trip begins, so ensure your bank holds enough supplies for the expected duration.
+
+## Location Notes
+
+- **Agility laps:** configure the background action before running [[/laps]]. You cannot alch on the Ape Atoll course because your minion must hold a greegree, but fletching still works there.
+- **Hallowed Sepulchre:** configure the action before [[/minigames sepulchre start]]. Zero-time alching and fletching both operate floor by floor without slowing your runs.
+
+Refer back to the [Agility guide](/osb/skills/agility) and [Hallowed Sepulchre guide](/osb/activities/hallowed-sepulchre) for activity-specific advice, boost information, and strategies.

--- a/docs/src/content/docs/osb/Skills/agility.md
+++ b/docs/src/content/docs/osb/Skills/agility.md
@@ -23,14 +23,14 @@ For max efficiency spam quantity 1 trips when close to leveling up.
 1. [[/minigames agility_arena start]] (for diary)
 1. [[/minigames rogues_den start]] (gear for thieving)
 
-## Agility Alching
+## Zero-time Activities While Training
 
-You can alch items while training Agility.
+Read the [Zero-time Activities guide](/osb/miscellaneous/zero-time-activities) for complete setup instructions before you start running laps.
 
-1. Select all the items you want to be alched while training: [[/config user favorite_alchs add\:Rune platebody]]
-1. After selecting your "Favorite alchable items" (favalchs), start a laps trip with `alch:True`, for example: [[/laps name\:Ardougne Rooftop Course alch\:True]]
+- [[/zero_time_activity type\:alch]] performs roughly 277 High Alchemy casts per hour while you train Agility. Leaving the item blank lets the bot choose from your favourite alchs at the start of every trip.
+- [[/zero_time_activity type\:fletch item\:"Rune dart"]] converts stackable ammunition at up to ~15,000 items per hour during rooftop laps.
 
-It will pick the highest alch-value item from your list of favorites to alch.
+Once configured, simply send [[/laps]] commands—zero-time actions happen automatically alongside your runs. Remember that the Ape Atoll course blocks alching because of the greegree requirement, although zero-time fletching still works there.
 
 ## Graceful
 

--- a/docs/src/content/docs/osb/Skills/fletching.md
+++ b/docs/src/content/docs/osb/Skills/fletching.md
@@ -15,16 +15,9 @@ You can train Fletching with the [[/fletch]] command. To see all the items you c
 1. [[/fletch name\:Rune dart]] until 95
 1. [[/fletch name\:Dragon dart]] until 99
 
-### Fletching at the Hallowed Sepulchre
+### Zero-time Fletching
 
-You can fletch certain "zero-time" items while completing laps of the Hallowed
-Sepulchre. Start a run with the `fletching:` option and specify the item ID you
-wish to fletch:
+Configure zero-time fletching with [[/zero_time_activity]], then run Agility laps or the Hallowed Sepulchre to craft ammunition in the background. The [Zero-time Activities guide](/osb/miscellaneous/zero-time-activities) lists every supported item, setup step, and hourly rate.
 
-- `[[/minigames sepulchre start fletching\:Rune dart]]`
-
-The following items can be fletched this way without increasing trip duration:
-Broad arrows, Broad bolts, Amethyst broad bolts, all types of darts, arrows,
-bolts, tipped bolts and javelins. The required items are removed from your bank
-at the start of the trip and your minion will fletch as many as possible while
-running the Sepulchre.
+- Example setup: [[/zero_time_activity type\:fletch item\:"Rune dart"]]
+- Zero-time alching is configured the same way with `type:alch`, and leaving the item blank lets the bot choose from your favourite alchs at the start of each trip.

--- a/src/mahoji/commands/zeroTimeActivity.ts
+++ b/src/mahoji/commands/zeroTimeActivity.ts
@@ -10,6 +10,12 @@ import { getZeroTimeActivitySettings } from '../../lib/util/zeroTimeActivity';
 
 const zeroTimeTypes: ZeroTimeActivityType[] = ['alch', 'fletch'];
 
+function getAutomaticSelectionText(type: ZeroTimeActivityType) {
+        return type === 'alch'
+                ? 'automatic selection from your favourite alchs each trip'
+                : 'automatic selection';
+}
+
 export const zeroTimeActivityCommand: OSBMahojiCommand = {
 	name: 'zero_time_activity',
 	description: 'Configure your preferred zero time activity.',
@@ -84,11 +90,12 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 			if (!currentSettings) {
 				return 'You currently have no zero time activity configured.';
 			}
-			const activityName = currentSettings.type === 'alch' ? 'Alching' : 'Fletching';
-			const itemName = currentSettings.itemID
-				? (Items.get(currentSettings.itemID)?.name ?? 'unknown item')
-				: 'automatic selection';
-			return `Your zero time activity is set to **${activityName}** using **${itemName}**.`;
+                        const activityName = currentSettings.type === 'alch' ? 'Alching' : 'Fletching';
+                        const itemName = currentSettings.itemID
+                                ? Items.get(currentSettings.itemID)?.name ?? 'unknown item'
+                                : null;
+                        const itemDisplay = itemName ?? getAutomaticSelectionText(currentSettings.type);
+                        return `Your zero time activity is set to **${activityName}** using **${itemDisplay}**.`;
 		}
 
 		if (!options.type) {
@@ -102,7 +109,7 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 
 		const type = typeInput as ZeroTimeActivityType;
 		let itemID: number | null = null;
-		let itemName = '';
+                let itemName: string | null = null;
 
 		if (type === 'alch') {
 			if (options.item) {
@@ -118,10 +125,8 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 				}
 				itemID = osItem.id;
 				itemName = osItem.name;
-			} else {
-				itemName = 'automatic selection';
-			}
-		} else {
+                        }
+                } else {
 			let fletchable = options.item
 				? zeroTimeFletchables.find(
 						item => stringMatches(item.name, options.item ?? '') || item.id === Number(options.item)
@@ -151,16 +156,17 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 			}
 
 			itemID = fletchable.id;
-			itemName = fletchable.name;
-		}
+                        itemName = fletchable.name;
+                }
 
-		await user.update({
-			zero_time_activity_type: type,
-			zero_time_activity_item: itemID
-		});
-		const activityName = type === 'alch' ? 'Alching' : 'Fletching';
-		const itemDisplay = itemID ? itemName : 'automatic selection';
+                await user.update({
+                        zero_time_activity_type: type,
+                        zero_time_activity_item: itemID
+                });
+                const activityName = type === 'alch' ? 'Alching' : 'Fletching';
+                const resolvedItemName = itemID ? itemName ?? Items.get(itemID)?.name ?? 'unknown item' : null;
+                const itemDisplay = resolvedItemName ?? getAutomaticSelectionText(type);
 
-		return `Your zero time activity has been set to **${activityName}** using **${itemDisplay}**.`;
-	}
+                return `Your zero time activity has been set to **${activityName}** using **${itemDisplay}**.`;
+        }
 };

--- a/tests/integration/commands/zeroTimeActivity.test.ts
+++ b/tests/integration/commands/zeroTimeActivity.test.ts
@@ -9,11 +9,12 @@ import { timePerAlch } from '../../../src/mahoji/lib/abstracted_commands/alchCom
 import { createTestUser } from '../util';
 
 describe('Zero Time Activity Command', () => {
-	test('persists alching configuration and uses it', async () => {
-		const item = Items.getOrThrow('Yew longbow');
-		const user = await createTestUser(new Bank().add('Nature rune', 200).add('Fire rune', 500).add(item.id, 200), {
-			skills_magic: convertLVLtoXP(75)
-		});
+        const automaticSelectionText = 'automatic selection from your favourite alchs each trip';
+        test('persists alching configuration and uses it', async () => {
+                const item = Items.getOrThrow('Yew longbow');
+                const user = await createTestUser(new Bank().add('Nature rune', 200).add('Fire rune', 500).add(item.id, 200), {
+                        skills_magic: convertLVLtoXP(75)
+                });
 
 		const response = await user.runCommand(zeroTimeActivityCommand, {
 			type: 'alch',
@@ -39,14 +40,36 @@ describe('Zero Time Activity Command', () => {
 			variant: 'default'
 		});
 
-		expect(activity.result?.type).toBe('alch');
-		expect(activity.result && activity.result.type === 'alch' ? activity.result.quantity : null).toBe(5);
-	});
+                expect(activity.result?.type).toBe('alch');
+                expect(activity.result && activity.result.type === 'alch' ? activity.result.quantity : null).toBe(5);
+        });
 
-	test('reuses configured fletching item on subsequent calls', async () => {
-		const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
-		expect(fletchable).toBeDefined();
-		if (!fletchable) return;
+        test('allows automatic alch selection', async () => {
+                const user = await createTestUser(new Bank().add('Nature rune', 200).add('Fire rune', 500), {
+                        skills_magic: convertLVLtoXP(75)
+                });
+
+                const response = await user.runCommand(zeroTimeActivityCommand, {
+                        type: 'alch'
+                });
+
+                expect(response).toBe(
+                        `Your zero time activity has been set to **Alching** using **${automaticSelectionText}**.`
+                );
+                await user.sync();
+                expect(user.user.zero_time_activity_type).toBe('alch');
+                expect(user.user.zero_time_activity_item).toBeNull();
+
+                const summary = await user.runCommand(zeroTimeActivityCommand, {});
+                expect(summary).toBe(
+                        `Your zero time activity is set to **Alching** using **${automaticSelectionText}**.`
+                );
+        });
+
+        test('reuses configured fletching item on subsequent calls', async () => {
+                const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
+                expect(fletchable).toBeDefined();
+                if (!fletchable) return;
 
 		const user = await createTestUser(new Bank().add('Steel dart tip', 500).add('Feather', 500), {
 			skills_fletching: convertLVLtoXP(75)


### PR DESCRIPTION
## Summary
- add a dedicated Zero-time Activities guide that explains `/zero_time_activity`, automatic alch selection, and hourly rates
- point the Agility, Hallowed Sepulchre, and Fletching pages at the new guide while keeping their unique zero-time notes brief