### PR TITLE
chore: format zero time activity modules

### DIFF
--- a/src/lib/skilling/skills/fletching/fletchables/index.ts
+++ b/src/lib/skilling/skills/fletching/fletchables/index.ts
@@ -30,28 +30,28 @@ export const Fletchables: Fletchable[] = [
 ];
 
 const zeroTimeFletchableCandidates: Fletchable[] = [
-        BroadArrows,
-        BroadBolts,
-        ...Darts,
-        ...Arrows,
-        ...Bolts,
-        AmethystBroadBolts,
-        ...TippedBolts,
-        ...TippedDragonBolts,
-        ...Javelins
+	BroadArrows,
+	BroadBolts,
+	...Darts,
+	...Arrows,
+	...Bolts,
+	AmethystBroadBolts,
+	...TippedBolts,
+	...TippedDragonBolts,
+	...Javelins
 ];
 
 export const zeroTimeFletchables: Fletchable[] = zeroTimeFletchableCandidates.filter(fletchable => {
-        const outputItem = Items.getOrThrow(fletchable.id);
-        if (!outputItem.stackable) {
-                return false;
-        }
+	const outputItem = Items.getOrThrow(fletchable.id);
+	if (!outputItem.stackable) {
+		return false;
+	}
 
-        for (const [item] of fletchable.inputItems.items()) {
-                if (!item.stackable) {
-                        return false;
-                }
-        }
+	for (const [item] of fletchable.inputItems.items()) {
+		if (!item.stackable) {
+			return false;
+		}
+	}
 
-        return true;
+	return true;
 });

--- a/src/mahoji/commands/zeroTimeActivity.ts
+++ b/src/mahoji/commands/zeroTimeActivity.ts
@@ -11,9 +11,7 @@ import { getZeroTimeActivitySettings } from '../../lib/util/zeroTimeActivity';
 const zeroTimeTypes: ZeroTimeActivityType[] = ['alch', 'fletch'];
 
 function getAutomaticSelectionText(type: ZeroTimeActivityType) {
-        return type === 'alch'
-                ? 'automatic selection from your favourite alchs each trip'
-                : 'automatic selection';
+	return type === 'alch' ? 'automatic selection from your favourite alchs each trip' : 'automatic selection';
 }
 
 export const zeroTimeActivityCommand: OSBMahojiCommand = {
@@ -90,12 +88,12 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 			if (!currentSettings) {
 				return 'You currently have no zero time activity configured.';
 			}
-                        const activityName = currentSettings.type === 'alch' ? 'Alching' : 'Fletching';
-                        const itemName = currentSettings.itemID
-                                ? Items.get(currentSettings.itemID)?.name ?? 'unknown item'
-                                : null;
-                        const itemDisplay = itemName ?? getAutomaticSelectionText(currentSettings.type);
-                        return `Your zero time activity is set to **${activityName}** using **${itemDisplay}**.`;
+			const activityName = currentSettings.type === 'alch' ? 'Alching' : 'Fletching';
+			const itemName = currentSettings.itemID
+				? (Items.get(currentSettings.itemID)?.name ?? 'unknown item')
+				: null;
+			const itemDisplay = itemName ?? getAutomaticSelectionText(currentSettings.type);
+			return `Your zero time activity is set to **${activityName}** using **${itemDisplay}**.`;
 		}
 
 		if (!options.type) {
@@ -109,7 +107,7 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 
 		const type = typeInput as ZeroTimeActivityType;
 		let itemID: number | null = null;
-                let itemName: string | null = null;
+		let itemName: string | null = null;
 
 		if (type === 'alch') {
 			if (options.item) {
@@ -125,8 +123,8 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 				}
 				itemID = osItem.id;
 				itemName = osItem.name;
-                        }
-                } else {
+			}
+		} else {
 			let fletchable = options.item
 				? zeroTimeFletchables.find(
 						item => stringMatches(item.name, options.item ?? '') || item.id === Number(options.item)
@@ -156,17 +154,17 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 			}
 
 			itemID = fletchable.id;
-                        itemName = fletchable.name;
-                }
+			itemName = fletchable.name;
+		}
 
-                await user.update({
-                        zero_time_activity_type: type,
-                        zero_time_activity_item: itemID
-                });
-                const activityName = type === 'alch' ? 'Alching' : 'Fletching';
-                const resolvedItemName = itemID ? itemName ?? Items.get(itemID)?.name ?? 'unknown item' : null;
-                const itemDisplay = resolvedItemName ?? getAutomaticSelectionText(type);
+		await user.update({
+			zero_time_activity_type: type,
+			zero_time_activity_item: itemID
+		});
+		const activityName = type === 'alch' ? 'Alching' : 'Fletching';
+		const resolvedItemName = itemID ? (itemName ?? Items.get(itemID)?.name ?? 'unknown item') : null;
+		const itemDisplay = resolvedItemName ?? getAutomaticSelectionText(type);
 
-                return `Your zero time activity has been set to **${activityName}** using **${itemDisplay}**.`;
-        }
+		return `Your zero time activity has been set to **${activityName}** using **${itemDisplay}**.`;
+	}
 };

--- a/src/mahoji/lib/abstracted_commands/sepulchreCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/sepulchreCommand.ts
@@ -64,13 +64,13 @@ export async function sepulchreCommand(user: MUser, channelID: string) {
 
 	if (zeroTimeSettings?.type === 'fletch') {
 		const configuredFletchable = zeroTimeFletchables.find(item => item.id === zeroTimeSettings.itemID);
-                let itemsPerHour: number | undefined;
-                if (configuredFletchable) {
-                        const timePerItem = getZeroTimeFletchTime(configuredFletchable);
-                        if (timePerItem) {
-                                const outputMultiple = configuredFletchable.outputMultiple ?? 1;
-                                itemsPerHour = (Time.Hour / timePerItem) * outputMultiple;
-                        }
+		let itemsPerHour: number | undefined;
+		if (configuredFletchable) {
+			const timePerItem = getZeroTimeFletchTime(configuredFletchable);
+			if (timePerItem) {
+				const outputMultiple = configuredFletchable.outputMultiple ?? 1;
+				itemsPerHour = (Time.Hour / timePerItem) * outputMultiple;
+			}
 		}
 
 		const zeroTime = attemptZeroTimeActivity({

--- a/tests/integration/commands/zeroTimeActivity.test.ts
+++ b/tests/integration/commands/zeroTimeActivity.test.ts
@@ -9,12 +9,12 @@ import { timePerAlch } from '../../../src/mahoji/lib/abstracted_commands/alchCom
 import { createTestUser } from '../util';
 
 describe('Zero Time Activity Command', () => {
-        const automaticSelectionText = 'automatic selection from your favourite alchs each trip';
-        test('persists alching configuration and uses it', async () => {
-                const item = Items.getOrThrow('Yew longbow');
-                const user = await createTestUser(new Bank().add('Nature rune', 200).add('Fire rune', 500).add(item.id, 200), {
-                        skills_magic: convertLVLtoXP(75)
-                });
+	const automaticSelectionText = 'automatic selection from your favourite alchs each trip';
+	test('persists alching configuration and uses it', async () => {
+		const item = Items.getOrThrow('Yew longbow');
+		const user = await createTestUser(new Bank().add('Nature rune', 200).add('Fire rune', 500).add(item.id, 200), {
+			skills_magic: convertLVLtoXP(75)
+		});
 
 		const response = await user.runCommand(zeroTimeActivityCommand, {
 			type: 'alch',
@@ -40,36 +40,34 @@ describe('Zero Time Activity Command', () => {
 			variant: 'default'
 		});
 
-                expect(activity.result?.type).toBe('alch');
-                expect(activity.result && activity.result.type === 'alch' ? activity.result.quantity : null).toBe(5);
-        });
+		expect(activity.result?.type).toBe('alch');
+		expect(activity.result && activity.result.type === 'alch' ? activity.result.quantity : null).toBe(5);
+	});
 
-        test('allows automatic alch selection', async () => {
-                const user = await createTestUser(new Bank().add('Nature rune', 200).add('Fire rune', 500), {
-                        skills_magic: convertLVLtoXP(75)
-                });
+	test('allows automatic alch selection', async () => {
+		const user = await createTestUser(new Bank().add('Nature rune', 200).add('Fire rune', 500), {
+			skills_magic: convertLVLtoXP(75)
+		});
 
-                const response = await user.runCommand(zeroTimeActivityCommand, {
-                        type: 'alch'
-                });
+		const response = await user.runCommand(zeroTimeActivityCommand, {
+			type: 'alch'
+		});
 
-                expect(response).toBe(
-                        `Your zero time activity has been set to **Alching** using **${automaticSelectionText}**.`
-                );
-                await user.sync();
-                expect(user.user.zero_time_activity_type).toBe('alch');
-                expect(user.user.zero_time_activity_item).toBeNull();
+		expect(response).toBe(
+			`Your zero time activity has been set to **Alching** using **${automaticSelectionText}**.`
+		);
+		await user.sync();
+		expect(user.user.zero_time_activity_type).toBe('alch');
+		expect(user.user.zero_time_activity_item).toBeNull();
 
-                const summary = await user.runCommand(zeroTimeActivityCommand, {});
-                expect(summary).toBe(
-                        `Your zero time activity is set to **Alching** using **${automaticSelectionText}**.`
-                );
-        });
+		const summary = await user.runCommand(zeroTimeActivityCommand, {});
+		expect(summary).toBe(`Your zero time activity is set to **Alching** using **${automaticSelectionText}**.`);
+	});
 
-        test('reuses configured fletching item on subsequent calls', async () => {
-                const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
-                expect(fletchable).toBeDefined();
-                if (!fletchable) return;
+	test('reuses configured fletching item on subsequent calls', async () => {
+		const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
+		expect(fletchable).toBeDefined();
+		if (!fletchable) return;
 
 		const user = await createTestUser(new Bank().add('Steel dart tip', 500).add('Feather', 500), {
 			skills_fletching: convertLVLtoXP(75)

--- a/tests/unit/zeroTimeActivity.test.ts
+++ b/tests/unit/zeroTimeActivity.test.ts
@@ -114,87 +114,83 @@ describe('attemptZeroTimeActivity', () => {
 		expect(response.result.timePerAction).toBeCloseTo(Time.Second * 0.2, 5);
 	});
 
-        test('fletching override matches default throughput for multi-output items', () => {
-                const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
-                expect(fletchable).toBeDefined();
-                if (!fletchable) return;
+	test('fletching override matches default throughput for multi-output items', () => {
+		const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
+		expect(fletchable).toBeDefined();
+		if (!fletchable) return;
 
-                const originalOutputMultiple = fletchable.outputMultiple;
-                fletchable.outputMultiple = 4;
+		const originalOutputMultiple = fletchable.outputMultiple;
+		fletchable.outputMultiple = 4;
 
-                try {
-                        const timePerItem = getZeroTimeFletchTime(fletchable);
-                        expect(timePerItem).not.toBeNull();
-                        if (!timePerItem) return;
+		try {
+			const timePerItem = getZeroTimeFletchTime(fletchable);
+			expect(timePerItem).not.toBeNull();
+			if (!timePerItem) return;
 
-                        const duration = Time.Hour;
-                        const outputMultiple = fletchable.outputMultiple ?? 1;
-                        const defaultSets = Math.floor(duration / timePerItem);
-                        const itemsPerHour = (Time.Hour / timePerItem) * outputMultiple;
+			const duration = Time.Hour;
+			const outputMultiple = fletchable.outputMultiple ?? 1;
+			const defaultSets = Math.floor(duration / timePerItem);
+			const itemsPerHour = (Time.Hour / timePerItem) * outputMultiple;
 
-                        const baseUser = mockMUser({
-                                bank: new Bank()
-                                        .add('Steel dart tip', defaultSets * 2)
-                                        .add('Feather', defaultSets * 2),
-                                skills_fletching: convertLVLtoXP(70),
-                                zero_time_activity_type: 'fletch',
-                                zero_time_activity_item: fletchable.id
-                        });
+			const baseUser = mockMUser({
+				bank: new Bank().add('Steel dart tip', defaultSets * 2).add('Feather', defaultSets * 2),
+				skills_fletching: convertLVLtoXP(70),
+				zero_time_activity_type: 'fletch',
+				zero_time_activity_item: fletchable.id
+			});
 
-                        const baseResponse = attemptZeroTimeActivity({
-                                type: 'fletch',
-                                user: baseUser,
-                                duration
-                        });
+			const baseResponse = attemptZeroTimeActivity({
+				type: 'fletch',
+				user: baseUser,
+				duration
+			});
 
-                        expect(baseResponse.result?.type).toBe('fletch');
-                        if (!baseResponse.result || baseResponse.result.type !== 'fletch') return;
+			expect(baseResponse.result?.type).toBe('fletch');
+			if (!baseResponse.result || baseResponse.result.type !== 'fletch') return;
 
-                        expect(baseResponse.result.quantity).toBe(defaultSets);
-                        expect(baseResponse.result.itemsToRemove.amount('Steel dart tip')).toBe(defaultSets);
-                        expect(baseResponse.result.itemsToRemove.amount('Feather')).toBe(defaultSets);
-                        expect(baseResponse.result.timePerAction).toBeCloseTo(timePerItem, 5);
+			expect(baseResponse.result.quantity).toBe(defaultSets);
+			expect(baseResponse.result.itemsToRemove.amount('Steel dart tip')).toBe(defaultSets);
+			expect(baseResponse.result.itemsToRemove.amount('Feather')).toBe(defaultSets);
+			expect(baseResponse.result.timePerAction).toBeCloseTo(timePerItem, 5);
 
-                        const overrideUser = mockMUser({
-                                bank: new Bank()
-                                        .add('Steel dart tip', defaultSets * 2)
-                                        .add('Feather', defaultSets * 2),
-                                skills_fletching: convertLVLtoXP(70),
-                                zero_time_activity_type: 'fletch',
-                                zero_time_activity_item: fletchable.id
-                        });
+			const overrideUser = mockMUser({
+				bank: new Bank().add('Steel dart tip', defaultSets * 2).add('Feather', defaultSets * 2),
+				skills_fletching: convertLVLtoXP(70),
+				zero_time_activity_type: 'fletch',
+				zero_time_activity_item: fletchable.id
+			});
 
-                        const overrideResponse = attemptZeroTimeActivity({
-                                type: 'fletch',
-                                user: overrideUser,
-                                duration,
-                                itemsPerHour
-                        });
+			const overrideResponse = attemptZeroTimeActivity({
+				type: 'fletch',
+				user: overrideUser,
+				duration,
+				itemsPerHour
+			});
 
-                        expect(overrideResponse.result?.type).toBe('fletch');
-                        if (!overrideResponse.result || overrideResponse.result.type !== 'fletch') return;
+			expect(overrideResponse.result?.type).toBe('fletch');
+			if (!overrideResponse.result || overrideResponse.result.type !== 'fletch') return;
 
-                        expect(overrideResponse.result.quantity).toBe(baseResponse.result.quantity);
-                        expect(overrideResponse.result.quantity).toBe(defaultSets);
-                        expect(overrideResponse.result.itemsToRemove.amount('Steel dart tip')).toBe(defaultSets);
-                        expect(overrideResponse.result.itemsToRemove.amount('Feather')).toBe(defaultSets);
-                        expect(overrideResponse.result.timePerAction).toBeCloseTo(duration / defaultSets, 5);
-                } finally {
-                        fletchable.outputMultiple = originalOutputMultiple;
-                }
-        });
+			expect(overrideResponse.result.quantity).toBe(baseResponse.result.quantity);
+			expect(overrideResponse.result.quantity).toBe(defaultSets);
+			expect(overrideResponse.result.itemsToRemove.amount('Steel dart tip')).toBe(defaultSets);
+			expect(overrideResponse.result.itemsToRemove.amount('Feather')).toBe(defaultSets);
+			expect(overrideResponse.result.timePerAction).toBeCloseTo(duration / defaultSets, 5);
+		} finally {
+			fletchable.outputMultiple = originalOutputMultiple;
+		}
+	});
 
-        test('zero time fletchables require stackable inputs and outputs', () => {
-                expect(zeroTimeFletchables.some(item => item.name === 'Wolfbone arrowtips')).toBe(false);
+	test('zero time fletchables require stackable inputs and outputs', () => {
+		expect(zeroTimeFletchables.some(item => item.name === 'Wolfbone arrowtips')).toBe(false);
 
-                for (const fletchable of zeroTimeFletchables) {
-                        const outputItem = Items.getOrThrow(fletchable.id);
-                        expect(outputItem.stackable).toBe(true);
-                        for (const [item] of fletchable.inputItems.items()) {
-                                expect(item.stackable).toBe(true);
-                        }
-                }
-        });
+		for (const fletchable of zeroTimeFletchables) {
+			const outputItem = Items.getOrThrow(fletchable.id);
+			expect(outputItem.stackable).toBe(true);
+			for (const [item] of fletchable.inputItems.items()) {
+				expect(item.stackable).toBe(true);
+			}
+		}
+	});
 
 	test('fletching failure without slayer unlock', () => {
 		const fletchable = zeroTimeFletchables.find(item => item.name === 'Broad arrows');


### PR DESCRIPTION
## Summary
- reformat zero-time fletching definitions to use Biome's tabbed indentation
- align zero-time command and test files with repository formatting rules

## Testing
- pnpm test:lint