### PR TITLE
Allow zero time activity item updates with stored type

### DIFF
--- a/src/mahoji/commands/zeroTimeActivity.ts
+++ b/src/mahoji/commands/zeroTimeActivity.ts
@@ -96,16 +96,23 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 			return `Your zero time activity is set to **${activityName}** using **${itemDisplay}**.`;
 		}
 
-		if (!options.type) {
-			return 'You must provide a type when setting a zero time activity.';
-		}
+                let type: ZeroTimeActivityType | null = null;
+                if (options.type) {
+                        const typeInput = options.type.toLowerCase();
+                        if (!zeroTimeTypes.includes(typeInput as ZeroTimeActivityType)) {
+                                return `Invalid zero time activity type. Valid options: ${zeroTimeTypes.join(', ')}.`;
+                        }
+                        type = typeInput as ZeroTimeActivityType;
+                } else if (options.item) {
+                        if (!currentSettings?.type) {
+                                return 'You must provide a type when setting a zero time activity.';
+                        }
+                        type = currentSettings.type;
+                }
 
-		const typeInput = options.type.toLowerCase();
-		if (!zeroTimeTypes.includes(typeInput as ZeroTimeActivityType)) {
-			return `Invalid zero time activity type. Valid options: ${zeroTimeTypes.join(', ')}.`;
-		}
-
-		const type = typeInput as ZeroTimeActivityType;
+                if (!type) {
+                        return 'You must provide a type when setting a zero time activity.';
+                }
 		let itemID: number | null = null;
 		let itemName: string | null = null;
 

--- a/tests/integration/commands/zeroTimeActivity.test.ts
+++ b/tests/integration/commands/zeroTimeActivity.test.ts
@@ -64,14 +64,14 @@ describe('Zero Time Activity Command', () => {
 		expect(summary).toBe(`Your zero time activity is set to **Alching** using **${automaticSelectionText}**.`);
 	});
 
-	test('reuses configured fletching item on subsequent calls', async () => {
-		const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
-		expect(fletchable).toBeDefined();
-		if (!fletchable) return;
+        test('reuses configured fletching item on subsequent calls', async () => {
+                const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
+                expect(fletchable).toBeDefined();
+                if (!fletchable) return;
 
-		const user = await createTestUser(new Bank().add('Steel dart tip', 500).add('Feather', 500), {
-			skills_fletching: convertLVLtoXP(75)
-		});
+                const user = await createTestUser(new Bank().add('Steel dart tip', 500).add('Feather', 500), {
+                        skills_fletching: convertLVLtoXP(75)
+                });
 
 		const firstResponse = await user.runCommand(zeroTimeActivityCommand, {
 			type: 'fletch',
@@ -100,8 +100,40 @@ describe('Zero Time Activity Command', () => {
 		});
 
 		expect(activity.result?.type).toBe('fletch');
-		expect(activity.result && activity.result.type === 'fletch' ? activity.result.quantity : null).toBeGreaterThan(
-			0
-		);
-	});
+                expect(activity.result && activity.result.type === 'fletch' ? activity.result.quantity : null).toBeGreaterThan(
+                        0
+                );
+        });
+
+        test('updates configured fletching item using stored type', async () => {
+                const firstFletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
+                const secondFletchable = zeroTimeFletchables.find(item => item.name === 'Mithril dart');
+                expect(firstFletchable).toBeDefined();
+                expect(secondFletchable).toBeDefined();
+                if (!firstFletchable || !secondFletchable) return;
+
+                const user = await createTestUser(
+                        new Bank().add('Steel dart tip', 500).add('Mithril dart tip', 500).add('Feather', 1000),
+                        {
+                                skills_fletching: convertLVLtoXP(75)
+                        }
+                );
+
+                await user.runCommand(zeroTimeActivityCommand, {
+                        type: 'fletch',
+                        item: firstFletchable.name
+                });
+                await user.sync();
+                expect(user.user.zero_time_activity_type).toBe('fletch');
+                expect(user.user.zero_time_activity_item).toBe(firstFletchable.id);
+
+                const updateResponse = await user.runCommand(zeroTimeActivityCommand, {
+                        item: secondFletchable.name
+                });
+
+                expect(updateResponse).toContain(secondFletchable.name);
+                await user.sync();
+                expect(user.user.zero_time_activity_type).toBe('fletch');
+                expect(user.user.zero_time_activity_item).toBe(secondFletchable.id);
+        });
 });


### PR DESCRIPTION
## Summary
- infer the zero time activity type from existing settings when only an item is provided
- keep validation for unknown types while allowing stored preferences to drive updates
- cover updating the saved fletching item using the previously configured type in integration tests

## Testing
- pnpm vitest run --config vitest.integration.config.mts tests/integration/commands/zeroTimeActivity.test.ts *(fails: requires database server at localhost:4444)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6fb436388326bd978bb7d3dbe4d4