### PR TITLE
Add Bryophyta rune savings to zero-time alching

### DIFF
--- a/src/lib/util/bryophytaRuneSavings.ts
+++ b/src/lib/util/bryophytaRuneSavings.ts
@@ -1,0 +1,33 @@
+import { Bank, itemID } from 'oldschooljs';
+
+import { roll } from './rng';
+
+const bryophytasStaffId = itemID("Bryophyta's staff");
+
+export function calculateBryophytaRuneSavings({
+        user,
+        quantity
+}: {
+        user: MUser;
+        quantity: number;
+}): { savedRunes: number; savedBank: Bank | null } {
+        if (quantity <= 0 || !user.hasEquipped(bryophytasStaffId)) {
+                return { savedRunes: 0, savedBank: null };
+        }
+
+        let savedRunes = 0;
+        for (let i = 0; i < quantity; i++) {
+                if (roll(15)) savedRunes++;
+        }
+
+        if (savedRunes === 0) {
+                return { savedRunes: 0, savedBank: null };
+        }
+
+        return {
+                savedRunes,
+                savedBank: new Bank({
+                        'Nature rune': savedRunes
+                })
+        };
+}

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -169,14 +169,13 @@ const tripHandlers = {
 		commandName: 'activities',
 		args: () => ({ aerial_fishing: {} })
 	},
-	[activity_type_enum.Agility]: {
-		commandName: 'laps',
-		args: (data: AgilityActivityTaskOptions) => ({
-			name: courses.find(c => c.id === data.courseID)?.name ?? data.courseID.toString(),
-			quantity: data.quantity,
-			alch: Boolean(data.alch)
-		})
-	},
+        [activity_type_enum.Agility]: {
+                commandName: 'laps',
+                args: (data: AgilityActivityTaskOptions) => ({
+                        name: courses.find(c => c.id === data.courseID)?.name ?? data.courseID.toString(),
+                        quantity: data.quantity
+                })
+        },
 	[activity_type_enum.AgilityArena]: {
 		commandName: 'minigames',
 		args: (data: ActivityTaskOptionsWithQuantity) => ({ agility_arena: { start: { quantity: data.quantity } } })

--- a/src/tasks/minions/agilityActivity.ts
+++ b/src/tasks/minions/agilityActivity.ts
@@ -8,6 +8,7 @@ import { zeroTimeFletchables } from '../../lib/skilling/skills/fletching/fletcha
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { AgilityActivityTaskOptions } from '../../lib/types/minions';
 import { skillingPetDropRate } from '../../lib/util';
+import { calculateBryophytaRuneSavings } from '../../lib/util/bryophytaRuneSavings';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
 import { logError } from '../../lib/util/logError';
 import { updateClientGPTrackSetting, userStatsUpdate } from '../../mahoji/mahojiSettings';
@@ -153,23 +154,36 @@ export const agilityTask: MinionTask = {
 			xpRes += ` ${fletchXpRes}`;
 		}
 
-		if (alch) {
-			const alchedItem = Items.getOrThrow(alch.itemID);
-			const alchGP = alchedItem.highalch! * alch.quantity;
-			loot.add('Coins', alchGP);
-			xpRes += ` ${await user.addXP({
-				skillName: SkillsEnum.Magic,
-				amount: alch.quantity * 65,
-				duration
-			})}`;
-			updateClientGPTrackSetting('gp_alch', alchGP);
-		}
+                let savedRunesFromAlching = 0;
+                if (alch) {
+                        const alchedItem = Items.getOrThrow(alch.itemID);
+                        const alchGP = alchedItem.highalch! * alch.quantity;
+                        loot.add('Coins', alchGP);
+                        const { savedRunes, savedBank } = calculateBryophytaRuneSavings({
+                                user,
+                                quantity: alch.quantity
+                        });
+                        savedRunesFromAlching = savedRunes;
+                        if (savedBank) {
+                                loot.add(savedBank);
+                        }
+                        xpRes += ` ${await user.addXP({
+                                skillName: SkillsEnum.Magic,
+                                amount: alch.quantity * 65,
+                                duration
+                        })}`;
+                        updateClientGPTrackSetting('gp_alch', alchGP);
+                }
 
-		let str = `${user}, ${user.minionName} finished ${quantity} ${
-			course.name
-		} laps and fell on ${lapsFailed} of them.\nYou received: ${loot}${
-			diaryBonus ? ' (25% bonus Marks for Ardougne Elite diary)' : ''
-		}.\n${xpRes}${monkeyStr}`;
+                let str = `${user}, ${user.minionName} finished ${quantity} ${
+                        course.name
+                } laps and fell on ${lapsFailed} of them.\nYou received: ${loot}${
+                        diaryBonus ? ' (25% bonus Marks for Ardougne Elite diary)' : ''
+                }.\n${xpRes}${monkeyStr}`;
+
+                if (savedRunesFromAlching > 0) {
+                        str += `\nYour Bryophyta's staff saved you ${savedRunesFromAlching} Nature runes.`;
+                }
 
 		if (fletchable && fletch && fletchQuantity > 0) {
 			const setsText = fletchable.outputMultiple ? ' sets of' : '';

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -1,50 +1,38 @@
-import { Bank, itemID } from 'oldschooljs';
+import { Bank } from 'oldschooljs';
 
 import { SkillsEnum } from '../../lib/skilling/types';
 import type { AlchingActivityTaskOptions } from '../../lib/types/minions';
+import { calculateBryophytaRuneSavings } from '../../lib/util/bryophytaRuneSavings';
 import getOSItem from '../../lib/util/getOSItem';
 import { handleTripFinish } from '../../lib/util/handleTripFinish';
-import { roll } from '../../lib/util/rng';
 import { updateClientGPTrackSetting } from '../../mahoji/mahojiSettings';
 
-const bryophytasStaffId = itemID("Bryophyta's staff");
-
 export const alchingTask: MinionTask = {
-	type: 'Alching',
-	async run(data: AlchingActivityTaskOptions) {
-		const { itemID, quantity, channelID, alchValue, userID, duration } = data;
-		const user = await mUserFetch(userID);
-		const loot = new Bank({ Coins: alchValue });
+        type: 'Alching',
+        async run(data: AlchingActivityTaskOptions) {
+                const { itemID, quantity, channelID, alchValue, userID, duration } = data;
+                const user = await mUserFetch(userID);
+                const loot = new Bank({ Coins: alchValue });
 
-		const item = getOSItem(itemID);
+                const item = getOSItem(itemID);
 
-		// If bryophyta's staff is equipped when starting the alch activity
-		// calculate how many runes have been saved
-		let savedRunes = 0;
-		if (user.hasEquipped(bryophytasStaffId)) {
-			for (let i = 0; i < quantity; i++) {
-				if (roll(15)) savedRunes++;
-			}
+                // If bryophyta's staff is equipped when starting the alch activity
+                // calculate how many runes have been saved
+                const { savedRunes, savedBank } = calculateBryophytaRuneSavings({ user, quantity });
+                if (savedBank) {
+                        loot.add(savedBank);
+                }
+                await user.addItemsToBank({ items: loot });
+                updateClientGPTrackSetting('gp_alch', alchValue);
 
-			if (savedRunes > 0) {
-				const returnedRunes = new Bank({
-					'Nature rune': savedRunes
-				});
-
-				loot.add(returnedRunes);
-			}
-		}
-		await user.addItemsToBank({ items: loot });
-		updateClientGPTrackSetting('gp_alch', alchValue);
-
-		const xpReceived = quantity * 65;
-		const xpRes = await user.addXP({
+                const xpReceived = quantity * 65;
+                const xpRes = await user.addXP({
 			skillName: SkillsEnum.Magic,
 			amount: xpReceived,
 			duration
-		});
+                });
 
-		const saved = savedRunes > 0 ? `Your Bryophyta's staff saved you ${savedRunes} Nature runes.` : '';
+                const saved = savedRunes > 0 ? `Your Bryophyta's staff saved you ${savedRunes} Nature runes.` : '';
 		const responses = [
 			`${user}, ${user.minionName} has finished alching ${quantity}x ${item.name}! ${loot} has been added to your bank. ${xpRes}. ${saved}`
 		].join('\n');


### PR DESCRIPTION
## Summary
- refactor Bryophyta's staff rune saving logic into a shared helper and apply it to alching trips
- add Nature rune refunds and messaging to agility and Sepulchre zero-time alching results
- simplify repeat stored trip agility arguments by dropping the unused alch flag