### PR TITLE
Fix Biome formatting for alching-related tasks

### DIFF
--- a/src/lib/util/bryophytaRuneSavings.ts
+++ b/src/lib/util/bryophytaRuneSavings.ts
@@ -5,29 +5,29 @@ import { roll } from './rng';
 const bryophytasStaffId = itemID("Bryophyta's staff");
 
 export function calculateBryophytaRuneSavings({
-        user,
-        quantity
+	user,
+	quantity
 }: {
-        user: MUser;
-        quantity: number;
+	user: MUser;
+	quantity: number;
 }): { savedRunes: number; savedBank: Bank | null } {
-        if (quantity <= 0 || !user.hasEquipped(bryophytasStaffId)) {
-                return { savedRunes: 0, savedBank: null };
-        }
+	if (quantity <= 0 || !user.hasEquipped(bryophytasStaffId)) {
+		return { savedRunes: 0, savedBank: null };
+	}
 
-        let savedRunes = 0;
-        for (let i = 0; i < quantity; i++) {
-                if (roll(15)) savedRunes++;
-        }
+	let savedRunes = 0;
+	for (let i = 0; i < quantity; i++) {
+		if (roll(15)) savedRunes++;
+	}
 
-        if (savedRunes === 0) {
-                return { savedRunes: 0, savedBank: null };
-        }
+	if (savedRunes === 0) {
+		return { savedRunes: 0, savedBank: null };
+	}
 
-        return {
-                savedRunes,
-                savedBank: new Bank({
-                        'Nature rune': savedRunes
-                })
-        };
+	return {
+		savedRunes,
+		savedBank: new Bank({
+			'Nature rune': savedRunes
+		})
+	};
 }

--- a/src/lib/util/repeatStoredTrip.ts
+++ b/src/lib/util/repeatStoredTrip.ts
@@ -169,13 +169,13 @@ const tripHandlers = {
 		commandName: 'activities',
 		args: () => ({ aerial_fishing: {} })
 	},
-        [activity_type_enum.Agility]: {
-                commandName: 'laps',
-                args: (data: AgilityActivityTaskOptions) => ({
-                        name: courses.find(c => c.id === data.courseID)?.name ?? data.courseID.toString(),
-                        quantity: data.quantity
-                })
-        },
+	[activity_type_enum.Agility]: {
+		commandName: 'laps',
+		args: (data: AgilityActivityTaskOptions) => ({
+			name: courses.find(c => c.id === data.courseID)?.name ?? data.courseID.toString(),
+			quantity: data.quantity
+		})
+	},
 	[activity_type_enum.AgilityArena]: {
 		commandName: 'minigames',
 		args: (data: ActivityTaskOptionsWithQuantity) => ({ agility_arena: { start: { quantity: data.quantity } } })

--- a/src/tasks/minions/agilityActivity.ts
+++ b/src/tasks/minions/agilityActivity.ts
@@ -154,36 +154,36 @@ export const agilityTask: MinionTask = {
 			xpRes += ` ${fletchXpRes}`;
 		}
 
-                let savedRunesFromAlching = 0;
-                if (alch) {
-                        const alchedItem = Items.getOrThrow(alch.itemID);
-                        const alchGP = alchedItem.highalch! * alch.quantity;
-                        loot.add('Coins', alchGP);
-                        const { savedRunes, savedBank } = calculateBryophytaRuneSavings({
-                                user,
-                                quantity: alch.quantity
-                        });
-                        savedRunesFromAlching = savedRunes;
-                        if (savedBank) {
-                                loot.add(savedBank);
-                        }
-                        xpRes += ` ${await user.addXP({
-                                skillName: SkillsEnum.Magic,
-                                amount: alch.quantity * 65,
-                                duration
-                        })}`;
-                        updateClientGPTrackSetting('gp_alch', alchGP);
-                }
+		let savedRunesFromAlching = 0;
+		if (alch) {
+			const alchedItem = Items.getOrThrow(alch.itemID);
+			const alchGP = alchedItem.highalch! * alch.quantity;
+			loot.add('Coins', alchGP);
+			const { savedRunes, savedBank } = calculateBryophytaRuneSavings({
+				user,
+				quantity: alch.quantity
+			});
+			savedRunesFromAlching = savedRunes;
+			if (savedBank) {
+				loot.add(savedBank);
+			}
+			xpRes += ` ${await user.addXP({
+				skillName: SkillsEnum.Magic,
+				amount: alch.quantity * 65,
+				duration
+			})}`;
+			updateClientGPTrackSetting('gp_alch', alchGP);
+		}
 
-                let str = `${user}, ${user.minionName} finished ${quantity} ${
-                        course.name
-                } laps and fell on ${lapsFailed} of them.\nYou received: ${loot}${
-                        diaryBonus ? ' (25% bonus Marks for Ardougne Elite diary)' : ''
-                }.\n${xpRes}${monkeyStr}`;
+		let str = `${user}, ${user.minionName} finished ${quantity} ${
+			course.name
+		} laps and fell on ${lapsFailed} of them.\nYou received: ${loot}${
+			diaryBonus ? ' (25% bonus Marks for Ardougne Elite diary)' : ''
+		}.\n${xpRes}${monkeyStr}`;
 
-                if (savedRunesFromAlching > 0) {
-                        str += `\nYour Bryophyta's staff saved you ${savedRunesFromAlching} Nature runes.`;
-                }
+		if (savedRunesFromAlching > 0) {
+			str += `\nYour Bryophyta's staff saved you ${savedRunesFromAlching} Nature runes.`;
+		}
 
 		if (fletchable && fletch && fletchQuantity > 0) {
 			const setsText = fletchable.outputMultiple ? ' sets of' : '';

--- a/src/tasks/minions/alchingActivity.ts
+++ b/src/tasks/minions/alchingActivity.ts
@@ -8,31 +8,31 @@ import { handleTripFinish } from '../../lib/util/handleTripFinish';
 import { updateClientGPTrackSetting } from '../../mahoji/mahojiSettings';
 
 export const alchingTask: MinionTask = {
-        type: 'Alching',
-        async run(data: AlchingActivityTaskOptions) {
-                const { itemID, quantity, channelID, alchValue, userID, duration } = data;
-                const user = await mUserFetch(userID);
-                const loot = new Bank({ Coins: alchValue });
+	type: 'Alching',
+	async run(data: AlchingActivityTaskOptions) {
+		const { itemID, quantity, channelID, alchValue, userID, duration } = data;
+		const user = await mUserFetch(userID);
+		const loot = new Bank({ Coins: alchValue });
 
-                const item = getOSItem(itemID);
+		const item = getOSItem(itemID);
 
-                // If bryophyta's staff is equipped when starting the alch activity
-                // calculate how many runes have been saved
-                const { savedRunes, savedBank } = calculateBryophytaRuneSavings({ user, quantity });
-                if (savedBank) {
-                        loot.add(savedBank);
-                }
-                await user.addItemsToBank({ items: loot });
-                updateClientGPTrackSetting('gp_alch', alchValue);
+		// If bryophyta's staff is equipped when starting the alch activity
+		// calculate how many runes have been saved
+		const { savedRunes, savedBank } = calculateBryophytaRuneSavings({ user, quantity });
+		if (savedBank) {
+			loot.add(savedBank);
+		}
+		await user.addItemsToBank({ items: loot });
+		updateClientGPTrackSetting('gp_alch', alchValue);
 
-                const xpReceived = quantity * 65;
-                const xpRes = await user.addXP({
+		const xpReceived = quantity * 65;
+		const xpRes = await user.addXP({
 			skillName: SkillsEnum.Magic,
 			amount: xpReceived,
 			duration
-                });
+		});
 
-                const saved = savedRunes > 0 ? `Your Bryophyta's staff saved you ${savedRunes} Nature runes.` : '';
+		const saved = savedRunes > 0 ? `Your Bryophyta's staff saved you ${savedRunes} Nature runes.` : '';
 		const responses = [
 			`${user}, ${user.minionName} has finished alching ${quantity}x ${item.name}! ${loot} has been added to your bank. ${xpRes}. ${saved}`
 		].join('\n');

--- a/src/tasks/minions/minigames/sepulchreActivity.ts
+++ b/src/tasks/minions/minigames/sepulchreActivity.ts
@@ -6,10 +6,10 @@ import { openCoffin, sepulchreFloors } from '../../../lib/minions/data/sepulchre
 import { zeroTimeFletchables } from '../../../lib/skilling/skills/fletching/fletchables';
 import { SkillsEnum } from '../../../lib/skilling/types';
 import type { SepulchreActivityTaskOptions } from '../../../lib/types/minions';
+import { calculateBryophytaRuneSavings } from '../../../lib/util/bryophytaRuneSavings';
 import { handleTripFinish } from '../../../lib/util/handleTripFinish';
 import { makeBankImage } from '../../../lib/util/makeBankImage';
 import { roll } from '../../../lib/util/rng';
-import { calculateBryophytaRuneSavings } from '../../../lib/util/bryophytaRuneSavings';
 import { updateClientGPTrackSetting } from '../../../mahoji/mahojiSettings';
 
 export const sepulchreTask: MinionTask = {
@@ -54,34 +54,34 @@ export const sepulchreTask: MinionTask = {
 
 		let fletchable: (typeof zeroTimeFletchables)[number] | undefined = undefined;
 
-                let savedRunesFromAlching = 0;
-                if (alch && alch.quantity > 0) {
-                        alchQuantity = alch.quantity;
-                        alchItem = Items.get(alch.itemID) ?? null;
+		let savedRunesFromAlching = 0;
+		if (alch && alch.quantity > 0) {
+			alchQuantity = alch.quantity;
+			alchItem = Items.get(alch.itemID) ?? null;
 
-                        if (!alchItem || !alchItem.highalch) {
-                                throw new Error(`Alch item id ${alch.itemID} not valid for Sepulchre alching.`);
+			if (!alchItem || !alchItem.highalch) {
+				throw new Error(`Alch item id ${alch.itemID} not valid for Sepulchre alching.`);
 			}
 
 			const alchGP = alchItem.highalch * alchQuantity;
-                        if (alchGP > 0) {
-                                loot.add('Coins', alchGP);
-                                updateClientGPTrackSetting('gp_alch', alchGP);
-                        }
+			if (alchGP > 0) {
+				loot.add('Coins', alchGP);
+				updateClientGPTrackSetting('gp_alch', alchGP);
+			}
 
-                        const { savedRunes, savedBank } = calculateBryophytaRuneSavings({
-                                user,
-                                quantity: alchQuantity
-                        });
-                        savedRunesFromAlching = savedRunes;
-                        if (savedBank) {
-                                loot.add(savedBank);
-                        }
+			const { savedRunes, savedBank } = calculateBryophytaRuneSavings({
+				user,
+				quantity: alchQuantity
+			});
+			savedRunesFromAlching = savedRunes;
+			if (savedBank) {
+				loot.add(savedBank);
+			}
 
-                        alchXpRes = await user.addXP({
-                                skillName: SkillsEnum.Magic,
-                                amount: alchQuantity * 65,
-                                duration
+			alchXpRes = await user.addXP({
+				skillName: SkillsEnum.Magic,
+				amount: alchQuantity * 65,
+				duration
 			});
 		}
 
@@ -171,14 +171,14 @@ export const sepulchreTask: MinionTask = {
 			}
 		}
 
-                if (alchItem && alchQuantity > 0) {
-                        str += `\nYou also alched ${alchQuantity}x ${alchItem.name}.`;
-                        if (savedRunesFromAlching > 0) {
-                                str += ` Your Bryophyta's staff saved you ${savedRunesFromAlching} Nature runes.`;
-                        }
-                } else if (savedRunesFromAlching > 0) {
-                        str += `\nYour Bryophyta's staff saved you ${savedRunesFromAlching} Nature runes.`;
-                }
+		if (alchItem && alchQuantity > 0) {
+			str += `\nYou also alched ${alchQuantity}x ${alchItem.name}.`;
+			if (savedRunesFromAlching > 0) {
+				str += ` Your Bryophyta's staff saved you ${savedRunesFromAlching} Nature runes.`;
+			}
+		} else if (savedRunesFromAlching > 0) {
+			str += `\nYour Bryophyta's staff saved you ${savedRunesFromAlching} Nature runes.`;
+		}
 
 		handleTripFinish(user, channelID, str, image.file.attachment, data, itemsAdded);
 	}


### PR DESCRIPTION
## Summary
- reorder the Bryophyta rune savings import in the Sepulchre minigame task
- restore tab-indented formatting for alching, agility, and shared rune-savings utilities to satisfy Biome linting