### PR TITLE
Organize vitest imports in herblore activity test

### DIFF
--- a/tests/unit/herbloreActivity.test.ts
+++ b/tests/unit/herbloreActivity.test.ts
@@ -1,6 +1,6 @@
 import { Bank } from 'oldschooljs';
-import { afterEach, describe, expect, test, vi } from 'vitest';
 import type { Mock } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import * as degradeableItemsModule from '../../src/lib/degradeableItems';
 import type { HerbloreActivityTaskOptions } from '../../src/lib/types/minions';


### PR DESCRIPTION
## Summary
- reorder the vitest type and value imports in the herblore activity unit test to satisfy Biome's import sorting rule

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68d39c4e21ac83269a9bdfd3c1475b9b