### PR TITLE
Fix herblore activity imports and tests

### DIFF
--- a/src/tasks/minions/herbloreActivity.ts
+++ b/src/tasks/minions/herbloreActivity.ts
@@ -1,11 +1,11 @@
-import { Bank, EItem, type Item } from 'oldschooljs';
+import { Bank, EItem, Items, type Item } from 'oldschooljs';
 
 import { userhasDiaryTier, WildernessDiary } from '@/lib/diaries.js';
 import Herblore from '@/lib/skilling/skills/herblore/herblore.js';
 import type { HerbloreActivityTaskOptions } from '@/lib/types/minions.js';
 import { handleTripFinish } from '@/lib/util/handleTripFinish.js';
 import { percentChance, randInt } from '@/lib/util/rng.js';
-import { checkDegradeableItemCharges, degradeItem } from '../../lib/degradeableItems';
+import { checkDegradeableItemCharges, degradeItem } from '../../lib/degradeableItems.js';
 
 export const herbloreTask: MinionTask = {
 	type: 'Herblore',
@@ -42,14 +42,10 @@ export const herbloreTask: MinionTask = {
 		}
 
 		if (!zahur && !wesley && mixableItem.item.name.includes('(3)')) {
-			const chemistryItem = getOSItem('Amulet of chemistry');
+                        const chemistryItem = Items.getOrThrow('Amulet of chemistry');
 			if (user.gear.skilling.hasEquipped(chemistryItem.id, false, false)) {
 				const potentialFourDoseName = mixableItem.item.name.replace(' (3)', '(4)').replace('(3)', '(4)');
-				try {
-					fourDoseItem = getOSItem(potentialFourDoseName);
-				} catch {
-					fourDoseItem = null;
-				}
+                                fourDoseItem = Items.get(potentialFourDoseName) ?? null;
 				if (fourDoseItem) {
 					const chemistryCharges = await checkDegradeableItemCharges({
 						item: chemistryItem,


### PR DESCRIPTION
## Summary
- ensure herblore activity uses explicit .js imports and the Old School JS Items helper
- update the herblore activity unit test to use the new imports and stub user transactions correctly

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d39de5a6188326bac720aa78ff3a79