### PR TITLE
Fix Lucky Penny formatting

### DIFF
--- a/src/lib/degradeableItems.ts
+++ b/src/lib/degradeableItems.ts
@@ -319,45 +319,45 @@ export function checkUserCanUseDegradeableItem({
 }
 
 export function shouldConsumeDegradeableCharge(user: MUser) {
-        if (!user.hasEquipped("Ghommal's lucky penny")) {
-                return true;
-        }
-        return !percentChance(5);
+	if (!user.hasEquipped("Ghommal's lucky penny")) {
+		return true;
+	}
+	return !percentChance(5);
 }
 
 export async function degradeItem({
-        item,
-        chargesToDegrade,
-        user,
-        applyLuckyPenny = true
+	item,
+	chargesToDegrade,
+	user,
+	applyLuckyPenny = true
 }: {
-        item: Item;
-        chargesToDegrade: number;
-        user: MUser;
-        applyLuckyPenny?: boolean;
+	item: Item;
+	chargesToDegrade: number;
+	user: MUser;
+	applyLuckyPenny?: boolean;
 }) {
-        const degItem = degradeableItems.find(i => i.item === item);
-        if (!degItem) throw new Error('Invalid degradeable item');
+	const degItem = degradeableItems.find(i => i.item === item);
+	if (!degItem) throw new Error('Invalid degradeable item');
 
-        let chargesSpent = chargesToDegrade;
+	let chargesSpent = chargesToDegrade;
 
-        if (applyLuckyPenny) {
-                chargesSpent = 0;
-                for (let i = 0; i < chargesToDegrade; i++) {
-                        if (shouldConsumeDegradeableCharge(user)) {
-                                chargesSpent++;
-                        }
-                }
-        }
+	if (applyLuckyPenny) {
+		chargesSpent = 0;
+		for (let i = 0; i < chargesToDegrade; i++) {
+			if (shouldConsumeDegradeableCharge(user)) {
+				chargesSpent++;
+			}
+		}
+	}
 
-        const currentCharges = user.user[degItem.settingsKey];
-        assert(typeof currentCharges === 'number');
-        const newCharges = Math.floor(currentCharges - chargesSpent);
+	const currentCharges = user.user[degItem.settingsKey];
+	assert(typeof currentCharges === 'number');
+	const newCharges = Math.floor(currentCharges - chargesSpent);
 
-        if (newCharges <= 0) {
-                // If no more charges left, break and refund the item.
-                const hasEquipped = user.gear[degItem.setup].hasEquipped(item.id, false);
-                const hasInBank = user.owns(item.id);
+	if (newCharges <= 0) {
+		// If no more charges left, break and refund the item.
+		const hasEquipped = user.gear[degItem.setup].hasEquipped(item.id, false);
+		const hasInBank = user.owns(item.id);
 		await user.update({
 			[degItem.settingsKey]: 0
 		});
@@ -389,25 +389,25 @@ export async function degradeItem({
 			});
 		} else {
 			// If its not in bank OR equipped, something weird has gone on.
-                        throw new Error(
-                                `${user.usernameOrMention} had missing ${item.name} when trying to degrade by ${chargesSpent}`
-                        );
-                }
+			throw new Error(
+				`${user.usernameOrMention} had missing ${item.name} when trying to degrade by ${chargesSpent}`
+			);
+		}
 
-                return {
-                        userMessage: `Your ${item.name} ran out of charges and broke.`
-                };
-        }
-        // If it has charges left still, just remove those charges and nothing else.
-        await user.update({
-                [degItem.settingsKey]: newCharges
-        });
-        const chargesAfter = user.user[degItem.settingsKey];
-        assert(typeof chargesAfter === 'number' && chargesAfter > 0);
-        return {
-                chargesToDegrade: chargesSpent,
-                userMessage: `Your ${item.name} degraded by ${chargesSpent} charges`
-        };
+		return {
+			userMessage: `Your ${item.name} ran out of charges and broke.`
+		};
+	}
+	// If it has charges left still, just remove those charges and nothing else.
+	await user.update({
+		[degItem.settingsKey]: newCharges
+	});
+	const chargesAfter = user.user[degItem.settingsKey];
+	assert(typeof chargesAfter === 'number' && chargesAfter > 0);
+	return {
+		chargesToDegrade: chargesSpent,
+		userMessage: `Your ${item.name} degraded by ${chargesSpent} charges`
+	};
 }
 
 export async function checkDegradeableItemCharges({ item, user }: { item: Item; user: MUser }) {

--- a/src/lib/skilling/functions/calcsRunecrafting.ts
+++ b/src/lib/skilling/functions/calcsRunecrafting.ts
@@ -5,36 +5,36 @@ import Runecraft from '@/lib/skilling/skills/runecraft.js';
 import { percentChance } from '@/lib/util/rng.js';
 
 export async function bloodEssence(user: MUser, quantity: number): Promise<number> {
-        let bonusQuantity = 0;
-        const bloodEssenceCharges = await checkDegradeableItemCharges({
-                item: Items.getOrThrow('Blood essence (active)'),
-                user
-        });
-        if (bloodEssenceCharges > 0) {
-                let chargesRemaining = bloodEssenceCharges;
-                let chargesConsumed = 0;
-                for (let i = 0; i < quantity; i++) {
-                        if (chargesRemaining <= 0) {
-                                break;
-                        }
-                        if (percentChance(50)) {
-                                bonusQuantity++;
-                                if (shouldConsumeDegradeableCharge(user)) {
-                                        chargesRemaining--;
-                                        chargesConsumed++;
-                                }
-                        }
-                }
-                if (chargesConsumed > 0) {
-                        await degradeItem({
-                                item: Items.getOrThrow('Blood essence (active)'),
-                                chargesToDegrade: chargesConsumed,
-                                user,
-                                applyLuckyPenny: false
-                        });
-                }
-        }
-        return bonusQuantity;
+	let bonusQuantity = 0;
+	const bloodEssenceCharges = await checkDegradeableItemCharges({
+		item: Items.getOrThrow('Blood essence (active)'),
+		user
+	});
+	if (bloodEssenceCharges > 0) {
+		let chargesRemaining = bloodEssenceCharges;
+		let chargesConsumed = 0;
+		for (let i = 0; i < quantity; i++) {
+			if (chargesRemaining <= 0) {
+				break;
+			}
+			if (percentChance(50)) {
+				bonusQuantity++;
+				if (shouldConsumeDegradeableCharge(user)) {
+					chargesRemaining--;
+					chargesConsumed++;
+				}
+			}
+		}
+		if (chargesConsumed > 0) {
+			await degradeItem({
+				item: Items.getOrThrow('Blood essence (active)'),
+				chargesToDegrade: chargesConsumed,
+				user,
+				applyLuckyPenny: false
+			});
+		}
+	}
+	return bonusQuantity;
 }
 
 export function raimentBonus(user: MUser, quantity: number): number {

--- a/tests/unit/degradeableItems.test.ts
+++ b/tests/unit/degradeableItems.test.ts
@@ -6,171 +6,171 @@ import { bloodEssence } from '@/lib/skilling/functions/calcsRunecrafting.js';
 import * as rngModule from '@/lib/util/rng.js';
 
 type FakeMUser = {
-        user: Record<string, number>;
-        hasEquipped: ReturnType<typeof vi.fn>;
-        gear: {
-                skilling: {
-                        hasEquipped: ReturnType<typeof vi.fn>;
-                };
-        };
-        update: ReturnType<typeof vi.fn>;
-        addItemsToBank: ReturnType<typeof vi.fn>;
-        transactItems: ReturnType<typeof vi.fn>;
-        owns: ReturnType<typeof vi.fn>;
-        usernameOrMention: string;
+	user: Record<string, number>;
+	hasEquipped: ReturnType<typeof vi.fn>;
+	gear: {
+		skilling: {
+			hasEquipped: ReturnType<typeof vi.fn>;
+		};
+	};
+	update: ReturnType<typeof vi.fn>;
+	addItemsToBank: ReturnType<typeof vi.fn>;
+	transactItems: ReturnType<typeof vi.fn>;
+	owns: ReturnType<typeof vi.fn>;
+	usernameOrMention: string;
 };
 
 function createTestUser({
-        bloodEssenceCharges = 0,
-        hasLuckyPenny = false
+	bloodEssenceCharges = 0,
+	hasLuckyPenny = false
 }: {
-        bloodEssenceCharges?: number;
-        hasLuckyPenny?: boolean;
+	bloodEssenceCharges?: number;
+	hasLuckyPenny?: boolean;
 } = {}) {
-        const base: FakeMUser = {
-                user: {
-                        blood_essence_charges: bloodEssenceCharges
-                },
-                hasEquipped: vi.fn((name: string) => hasLuckyPenny && name === "Ghommal's lucky penny"),
-                gear: {
-                        skilling: {
-                                hasEquipped: vi.fn().mockReturnValue(false)
-                        }
-                },
-                update: vi.fn(async (data: Record<string, number>) => {
-                        base.user = { ...base.user, ...data };
-                        return { newUser: base.user };
-                }),
-                addItemsToBank: vi.fn().mockResolvedValue(undefined),
-                transactItems: vi.fn().mockResolvedValue(undefined),
-                owns: vi.fn().mockReturnValue(false),
-                usernameOrMention: 'TestUser'
-        };
-        return base;
+	const base: FakeMUser = {
+		user: {
+			blood_essence_charges: bloodEssenceCharges
+		},
+		hasEquipped: vi.fn((name: string) => hasLuckyPenny && name === "Ghommal's lucky penny"),
+		gear: {
+			skilling: {
+				hasEquipped: vi.fn().mockReturnValue(false)
+			}
+		},
+		update: vi.fn(async (data: Record<string, number>) => {
+			base.user = { ...base.user, ...data };
+			return { newUser: base.user };
+		}),
+		addItemsToBank: vi.fn().mockResolvedValue(undefined),
+		transactItems: vi.fn().mockResolvedValue(undefined),
+		owns: vi.fn().mockReturnValue(false),
+		usernameOrMention: 'TestUser'
+	};
+	return base;
 }
 
 const { degradeItem, shouldConsumeDegradeableCharge } = degradeableItemsModule;
 type TestMUser = Parameters<typeof shouldConsumeDegradeableCharge>[0];
 
 afterEach(() => {
-        vi.restoreAllMocks();
+	vi.restoreAllMocks();
 });
 
 describe('shouldConsumeDegradeableCharge', () => {
-        test('always consumes when the user lacks a lucky penny', () => {
-                const user = createTestUser();
-                const percentSpy = vi.spyOn(rngModule, 'percentChance');
-                expect(shouldConsumeDegradeableCharge(user as unknown as TestMUser)).toBe(true);
-                expect(percentSpy).not.toHaveBeenCalled();
-        });
+	test('always consumes when the user lacks a lucky penny', () => {
+		const user = createTestUser();
+		const percentSpy = vi.spyOn(rngModule, 'percentChance');
+		expect(shouldConsumeDegradeableCharge(user as unknown as TestMUser)).toBe(true);
+		expect(percentSpy).not.toHaveBeenCalled();
+	});
 
-        test('refunds a charge when the penny roll succeeds', () => {
-                const user = createTestUser({ hasLuckyPenny: true });
-                const percentSpy = vi.spyOn(rngModule, 'percentChance').mockReturnValue(true);
-                expect(shouldConsumeDegradeableCharge(user as unknown as TestMUser)).toBe(false);
-                expect(percentSpy).toHaveBeenCalledWith(5);
-        });
+	test('refunds a charge when the penny roll succeeds', () => {
+		const user = createTestUser({ hasLuckyPenny: true });
+		const percentSpy = vi.spyOn(rngModule, 'percentChance').mockReturnValue(true);
+		expect(shouldConsumeDegradeableCharge(user as unknown as TestMUser)).toBe(false);
+		expect(percentSpy).toHaveBeenCalledWith(5);
+	});
 
-        test('consumes a charge when the penny roll fails', () => {
-                const user = createTestUser({ hasLuckyPenny: true });
-                const percentSpy = vi.spyOn(rngModule, 'percentChance').mockReturnValue(false);
-                expect(shouldConsumeDegradeableCharge(user as unknown as TestMUser)).toBe(true);
-                expect(percentSpy).toHaveBeenCalledWith(5);
-        });
+	test('consumes a charge when the penny roll fails', () => {
+		const user = createTestUser({ hasLuckyPenny: true });
+		const percentSpy = vi.spyOn(rngModule, 'percentChance').mockReturnValue(false);
+		expect(shouldConsumeDegradeableCharge(user as unknown as TestMUser)).toBe(true);
+		expect(percentSpy).toHaveBeenCalledWith(5);
+	});
 });
 
 describe('degradeItem', () => {
-        test('skips lucky penny rolls when requested', async () => {
-                const user = createTestUser({ bloodEssenceCharges: 10 });
-                const item = Items.getOrThrow('Blood essence (active)');
-                const result = await degradeItem({
-                        item,
-                        chargesToDegrade: 3,
-                        user: user as unknown as TestMUser,
-                        applyLuckyPenny: false
-                });
-                expect(user.update).toHaveBeenCalledWith({ blood_essence_charges: 7 });
-                expect(user.user.blood_essence_charges).toBe(7);
-                expect(result).toStrictEqual({
-                        chargesToDegrade: 3,
-                        userMessage: `Your ${item.name} degraded by 3 charges`
-                });
-        });
+	test('skips lucky penny rolls when requested', async () => {
+		const user = createTestUser({ bloodEssenceCharges: 10 });
+		const item = Items.getOrThrow('Blood essence (active)');
+		const result = await degradeItem({
+			item,
+			chargesToDegrade: 3,
+			user: user as unknown as TestMUser,
+			applyLuckyPenny: false
+		});
+		expect(user.update).toHaveBeenCalledWith({ blood_essence_charges: 7 });
+		expect(user.user.blood_essence_charges).toBe(7);
+		expect(result).toStrictEqual({
+			chargesToDegrade: 3,
+			userMessage: `Your ${item.name} degraded by 3 charges`
+		});
+	});
 
-        test('applies lucky penny rolls charge by charge', async () => {
-                const user = createTestUser({ bloodEssenceCharges: 10, hasLuckyPenny: true });
-                const item = Items.getOrThrow('Blood essence (active)');
-                const percentSpy = vi
-                        .spyOn(rngModule, 'percentChance')
-                        .mockImplementationOnce(() => true)
-                        .mockImplementationOnce(() => false)
-                        .mockImplementationOnce(() => false)
-                        .mockImplementationOnce(() => true);
-                const result = await degradeItem({
-                        item,
-                        chargesToDegrade: 4,
-                        user: user as unknown as TestMUser
-                });
-                expect(percentSpy).toHaveBeenCalledTimes(4);
-                for (let i = 1; i <= 4; i++) {
-                        expect(percentSpy).toHaveBeenNthCalledWith(i, 5);
-                }
-                expect(user.update).toHaveBeenCalledWith({ blood_essence_charges: 8 });
-                expect(user.user.blood_essence_charges).toBe(8);
-                expect(result).toStrictEqual({
-                        chargesToDegrade: 2,
-                        userMessage: `Your ${item.name} degraded by 2 charges`
-                });
-        });
+	test('applies lucky penny rolls charge by charge', async () => {
+		const user = createTestUser({ bloodEssenceCharges: 10, hasLuckyPenny: true });
+		const item = Items.getOrThrow('Blood essence (active)');
+		const percentSpy = vi
+			.spyOn(rngModule, 'percentChance')
+			.mockImplementationOnce(() => true)
+			.mockImplementationOnce(() => false)
+			.mockImplementationOnce(() => false)
+			.mockImplementationOnce(() => true);
+		const result = await degradeItem({
+			item,
+			chargesToDegrade: 4,
+			user: user as unknown as TestMUser
+		});
+		expect(percentSpy).toHaveBeenCalledTimes(4);
+		for (let i = 1; i <= 4; i++) {
+			expect(percentSpy).toHaveBeenNthCalledWith(i, 5);
+		}
+		expect(user.update).toHaveBeenCalledWith({ blood_essence_charges: 8 });
+		expect(user.user.blood_essence_charges).toBe(8);
+		expect(result).toStrictEqual({
+			chargesToDegrade: 2,
+			userMessage: `Your ${item.name} degraded by 2 charges`
+		});
+	});
 });
 
 describe('bloodEssence', () => {
-        test('honors mid-trip lucky penny refunds', async () => {
-                const user = createTestUser({ bloodEssenceCharges: 4, hasLuckyPenny: true });
-                const percentSpy = vi
-                        .spyOn(rngModule, 'percentChance')
-                        .mockImplementationOnce(() => true)
-                        .mockImplementationOnce(() => true)
-                        .mockImplementationOnce(() => false)
-                        .mockImplementationOnce(() => true)
-                        .mockImplementationOnce(() => true);
-                const shouldConsumeSpy = vi
-                        .spyOn(degradeableItemsModule, 'shouldConsumeDegradeableCharge')
-                        .mockImplementationOnce(() => true)
-                        .mockImplementationOnce(() => false)
-                        .mockImplementationOnce(() => true)
-                        .mockImplementationOnce(() => true);
-                const degradeItemSpy = vi.spyOn(degradeableItemsModule, 'degradeItem');
+	test('honors mid-trip lucky penny refunds', async () => {
+		const user = createTestUser({ bloodEssenceCharges: 4, hasLuckyPenny: true });
+		const percentSpy = vi
+			.spyOn(rngModule, 'percentChance')
+			.mockImplementationOnce(() => true)
+			.mockImplementationOnce(() => true)
+			.mockImplementationOnce(() => false)
+			.mockImplementationOnce(() => true)
+			.mockImplementationOnce(() => true);
+		const shouldConsumeSpy = vi
+			.spyOn(degradeableItemsModule, 'shouldConsumeDegradeableCharge')
+			.mockImplementationOnce(() => true)
+			.mockImplementationOnce(() => false)
+			.mockImplementationOnce(() => true)
+			.mockImplementationOnce(() => true);
+		const degradeItemSpy = vi.spyOn(degradeableItemsModule, 'degradeItem');
 
-                const bonus = await bloodEssence(user as unknown as TestMUser, 5);
+		const bonus = await bloodEssence(user as unknown as TestMUser, 5);
 
-                expect(percentSpy).toHaveBeenCalledTimes(5);
-                expect(shouldConsumeSpy).toHaveBeenCalledTimes(4);
-                expect(bonus).toBe(4);
-                expect(degradeItemSpy).toHaveBeenCalledTimes(1);
-                const degradeCall = degradeItemSpy.mock.calls[0][0];
-                expect(degradeCall.chargesToDegrade).toBe(3);
-                expect(degradeCall.applyLuckyPenny).toBe(false);
-                expect(degradeCall.user).toBe(user);
-                expect(degradeCall.item.name).toBe('Blood essence (active)');
-                expect(user.user.blood_essence_charges).toBe(1);
-        });
+		expect(percentSpy).toHaveBeenCalledTimes(5);
+		expect(shouldConsumeSpy).toHaveBeenCalledTimes(4);
+		expect(bonus).toBe(4);
+		expect(degradeItemSpy).toHaveBeenCalledTimes(1);
+		const degradeCall = degradeItemSpy.mock.calls[0][0];
+		expect(degradeCall.chargesToDegrade).toBe(3);
+		expect(degradeCall.applyLuckyPenny).toBe(false);
+		expect(degradeCall.user).toBe(user);
+		expect(degradeCall.item.name).toBe('Blood essence (active)');
+		expect(user.user.blood_essence_charges).toBe(1);
+	});
 
-        test('skips degrading when every proc is refunded', async () => {
-                const user = createTestUser({ bloodEssenceCharges: 3, hasLuckyPenny: true });
-                const percentSpy = vi
-                        .spyOn(rngModule, 'percentChance')
-                        .mockImplementationOnce(() => true)
-                        .mockImplementationOnce(() => true)
-                        .mockImplementationOnce(() => true);
-                vi.spyOn(degradeableItemsModule, 'shouldConsumeDegradeableCharge').mockReturnValue(false);
-                const degradeItemSpy = vi.spyOn(degradeableItemsModule, 'degradeItem');
+	test('skips degrading when every proc is refunded', async () => {
+		const user = createTestUser({ bloodEssenceCharges: 3, hasLuckyPenny: true });
+		const percentSpy = vi
+			.spyOn(rngModule, 'percentChance')
+			.mockImplementationOnce(() => true)
+			.mockImplementationOnce(() => true)
+			.mockImplementationOnce(() => true);
+		vi.spyOn(degradeableItemsModule, 'shouldConsumeDegradeableCharge').mockReturnValue(false);
+		const degradeItemSpy = vi.spyOn(degradeableItemsModule, 'degradeItem');
 
-                const bonus = await bloodEssence(user as unknown as TestMUser, 3);
+		const bonus = await bloodEssence(user as unknown as TestMUser, 3);
 
-                expect(percentSpy).toHaveBeenCalledTimes(3);
-                expect(bonus).toBe(3);
-                expect(degradeItemSpy).not.toHaveBeenCalled();
-                expect(user.user.blood_essence_charges).toBe(3);
-        });
+		expect(percentSpy).toHaveBeenCalledTimes(3);
+		expect(bonus).toBe(3);
+		expect(degradeItemSpy).not.toHaveBeenCalled();
+		expect(user.user.blood_essence_charges).toBe(3);
+	});
 });


### PR DESCRIPTION
## Summary
- apply repository formatting to the Lucky Penny handling in the degradeable item helpers
- normalize indentation for the blood essence bonus logic and its accompanying unit tests

## Testing
- pnpm test:lint
- pnpm test:unit -- --run tests/unit/degradeableItems.test.ts *(fails: Vitest cannot resolve the workspace package `oldschooljs` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f28c18bc83269a876e71f247f48e