### PR TITLE
Remove unused imports in farming command

### DIFF
--- a/src/mahoji/lib/abstracted_commands/farmingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingCommand.ts
@@ -5,11 +5,9 @@ import type { ChatInputCommandInteraction } from 'discord.js';
 import { Bank } from 'oldschooljs';
 
 import { superCompostables } from '@/lib/data/filterables.js';
-import { ArdougneDiary, userhasDiaryTier } from '@/lib/diaries.js';
 import { calcNumOfPatches } from '@/lib/skilling/functions/calcsFarming.js';
 import { getFarmingInfo, getFarmingInfoFromUser } from '@/lib/skilling/functions/getFarmingInfo.js';
 import Farming from '@/lib/skilling/skills/farming/index.js';
-import type { Plant } from '@/lib/skilling/types.js';
 import { SkillsEnum } from '@/lib/skilling/types.js';
 import { prepareFarmingStep, treeCheck } from '@/lib/minions/functions/farmingTripHelpers.js';
 import type { FarmingActivityTaskOptions } from '@/lib/types/minions.js';


### PR DESCRIPTION
## Summary
- remove unused diary and Plant imports from the farming command

## Testing
- pnpm lint *(fails: missing module @oldschoolgg/toolkit/dist/esm/structures.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68d40530f1b48326a18d2ba6cbb9f9ec