### PR TITLE
Fix auto farm step timestamps

### DIFF
--- a/src/lib/minions/functions/autoFarm.ts
+++ b/src/lib/minions/functions/autoFarm.ts
@@ -142,6 +142,8 @@ export async function autoFarm(
 	await userStatsBankUpdate(user, 'farming_plant_cost_bank', totalCost);
 
 	const autoFarmPlan: AutoFarmStepData[] = [];
+	const planningStartTime = Date.now();
+	let accumulatedDuration = 0;
 	for (const step of plannedSteps) {
 		const inserted = await prisma.farmedCrop.create({
 			data: {
@@ -162,10 +164,11 @@ export async function autoFarm(
 			payment: step.didPay,
 			patchType: step.patch,
 			planting: true,
-			currentDate: Date.now(),
+			currentDate: planningStartTime + accumulatedDuration,
 			duration: step.duration,
 			pid: inserted.id
 		});
+		accumulatedDuration += step.duration;
 	}
 
 	const [firstStep, ...remainingSteps] = autoFarmPlan;


### PR DESCRIPTION
## Summary
- preserve accurate planting timestamps for auto-farming steps by basing them on the planned start time plus elapsed durations

## Testing
- pnpm lint *(fails: missing @oldschoolgg/toolkit dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d462c2a48326a9e055ce7db680ba