### PR TITLE
Fix formatting for farming trip helpers

### DIFF
--- a/src/lib/minions/functions/farmingTripHelpers.ts
+++ b/src/lib/minions/functions/farmingTripHelpers.ts
@@ -96,30 +96,27 @@ export async function prepareFarmingStep({
 		};
 	}
 
-        const inputItems = [...plant.inputItems.items()];
-        for (const [seed, qty] of inputItems) {
-                const availableQty = availableBank.amount(seed.id);
-                if (availableQty < qty) {
-                        const singleCost = new Bank().add(seed.id, qty);
-                        return { success: false, error: `You don't own ${singleCost}.` };
-                }
-                const maxForThisSeed = Math.floor(availableQty / qty);
-                quantityToDo = Math.min(quantityToDo, maxForThisSeed);
-        }
+	const inputItems = [...plant.inputItems.items()];
+	for (const [seed, qty] of inputItems) {
+		const availableQty = availableBank.amount(seed.id);
+		if (availableQty < qty) {
+			const singleCost = new Bank().add(seed.id, qty);
+			return { success: false, error: `You don't own ${singleCost}.` };
+		}
+		const maxForThisSeed = Math.floor(availableQty / qty);
+		quantityToDo = Math.min(quantityToDo, maxForThisSeed);
+	}
 
-        if (quantityToDo <= 0) {
-                const minimumCost = inputItems.reduce((bank, [seed, qty]) => bank.add(seed.id, qty), new Bank());
-                return { success: false, error: `You don't own ${minimumCost}.` };
-        }
+	if (quantityToDo <= 0) {
+		const minimumCost = inputItems.reduce((bank, [seed, qty]) => bank.add(seed.id, qty), new Bank());
+		return { success: false, error: `You don't own ${minimumCost}.` };
+	}
 
-        const cost = inputItems.reduce(
-                (bank, [seed, qty]) => bank.add(seed.id, qty * quantityToDo),
-                new Bank()
-        );
+	const cost = inputItems.reduce((bank, [seed, qty]) => bank.add(seed.id, qty * quantityToDo), new Bank());
 
-        if (!availableBank.has(cost)) {
-                return { success: false, error: `You don't own ${cost}.` };
-        }
+	if (!availableBank.has(cost)) {
+		return { success: false, error: `You don't own ${cost}.` };
+	}
 
 	const wantsToPay = (pay || user.user.minion_defaultPay) && plant.canPayFarmer;
 	let didPay = false;
@@ -141,47 +138,47 @@ export async function prepareFarmingStep({
 			infoStr.push(`You are treating your patches with ${compostCost}.`);
 			cost.add(compostCost);
 			upgradeType = compostTier;
-                }
-        }
+		}
+	}
 
-        let duration = 0;
-        if (patchDetailed.patchPlanted) {
-                duration = patchDetailed.lastQuantity * (timePerPatchTravel + timePerPatchPlant + timePerPatchHarvest);
-                if (quantityToDo > patchDetailed.lastQuantity) {
-                        duration += (quantityToDo - patchDetailed.lastQuantity) * (timePerPatchTravel + timePerPatchPlant);
-                }
-        } else {
-                duration = quantityToDo * (timePerPatchTravel + timePerPatchPlant);
-        }
+	let duration = 0;
+	if (patchDetailed.patchPlanted) {
+		duration = patchDetailed.lastQuantity * (timePerPatchTravel + timePerPatchPlant + timePerPatchHarvest);
+		if (quantityToDo > patchDetailed.lastQuantity) {
+			duration += (quantityToDo - patchDetailed.lastQuantity) * (timePerPatchTravel + timePerPatchPlant);
+		}
+	} else {
+		duration = quantityToDo * (timePerPatchTravel + timePerPatchPlant);
+	}
 
-        if (userHasGracefulEquipped(user)) {
-                boostStr.push('10% time for Graceful');
-                duration *= 0.9;
-        }
+	if (userHasGracefulEquipped(user)) {
+		boostStr.push('10% time for Graceful');
+		duration *= 0.9;
+	}
 
-        if (user.hasEquipped('Ring of endurance')) {
-                boostStr.push('10% time for Ring of Endurance');
-                duration *= 0.9;
-        }
+	if (user.hasEquipped('Ring of endurance')) {
+		boostStr.push('10% time for Ring of Endurance');
+		duration *= 0.9;
+	}
 
-        for (const [diary, tier] of [[ArdougneDiary, ArdougneDiary.elite]] as const) {
-                const [has] = await userhasDiaryTier(user, tier);
-                if (has) {
-                        boostStr.push(`4% time for ${diary.name} ${tier.name}`);
-                        duration *= 0.96;
-                }
-        }
+	for (const [diary, tier] of [[ArdougneDiary, ArdougneDiary.elite]] as const) {
+		const [has] = await userhasDiaryTier(user, tier);
+		if (has) {
+			boostStr.push(`4% time for ${diary.name} ${tier.name}`);
+			duration *= 0.96;
+		}
+	}
 
-        if (duration > maxTripLength) {
-                return {
-                        success: false,
-                        error: `${user.minionName} can't go on trips longer than ${formatDuration(maxTripLength)}, try a lower quantity. The highest amount of ${plant.name} you can plant is ${maxCanDo}.`
-                };
-        }
+	if (duration > maxTripLength) {
+		return {
+			success: false,
+			error: `${user.minionName} can't go on trips longer than ${formatDuration(maxTripLength)}, try a lower quantity. The highest amount of ${plant.name} you can plant is ${maxCanDo}.`
+		};
+	}
 
-        return {
-                success: true,
-                data: {
+	return {
+		success: true,
+		data: {
 			quantity: quantityToDo,
 			duration,
 			cost,

--- a/tests/unit/autoFarm.test.ts
+++ b/tests/unit/autoFarm.test.ts
@@ -9,50 +9,50 @@ import Farming from '../../src/lib/skilling/skills/farming/index.js';
 import { mockMUser } from './userutil.js';
 
 describe('prepareFarmingStep auto farm limits', () => {
-        it('charges only for the achievable quantity when inputs differ', async () => {
-                const user = mockMUser({
-                        bank: new Bank({ 'Grape seed': 5, Saltpetre: 1 }),
-                        QP: 200
-                });
-                user.user.skills_farming = convertLVLtoXP(99);
+	it('charges only for the achievable quantity when inputs differ', async () => {
+		const user = mockMUser({
+			bank: new Bank({ 'Grape seed': 5, Saltpetre: 1 }),
+			QP: 200
+		});
+		user.user.skills_farming = convertLVLtoXP(99);
 
-                const grapePlant = Farming.Plants.find(plant => plant.name === 'Grape');
-                if (!grapePlant) {
-                        throw new Error('Expected grape plant data');
-                }
+		const grapePlant = Farming.Plants.find(plant => plant.name === 'Grape');
+		if (!grapePlant) {
+			throw new Error('Expected grape plant data');
+		}
 
-                const patchDetailed: IPatchDataDetailed = {
-                        ready: true,
-                        readyIn: null,
-                        readyAt: null,
-                        patchName: 'vine',
-                        friendlyName: 'Grape patch',
-                        plant: null,
-                        lastPlanted: null,
-                        patchPlanted: false,
-                        plantTime: Date.now(),
-                        lastQuantity: 0,
-                        lastUpgradeType: null,
-                        lastPayment: false
-                };
+		const patchDetailed: IPatchDataDetailed = {
+			ready: true,
+			readyIn: null,
+			readyAt: null,
+			patchName: 'vine',
+			friendlyName: 'Grape patch',
+			plant: null,
+			lastPlanted: null,
+			patchPlanted: false,
+			plantTime: Date.now(),
+			lastQuantity: 0,
+			lastUpgradeType: null,
+			lastPayment: false
+		};
 
-                const availableBank = user.bank.clone();
-                const prepared = await prepareFarmingStep({
-                        user,
-                        plant: grapePlant,
-                        quantity: null,
-                        pay: false,
-                        patchDetailed,
-                        maxTripLength: Time.Hour * 10,
-                        availableBank,
-                        compostTier: 'compost' as CropUpgradeType
-                });
+		const availableBank = user.bank.clone();
+		const prepared = await prepareFarmingStep({
+			user,
+			plant: grapePlant,
+			quantity: null,
+			pay: false,
+			patchDetailed,
+			maxTripLength: Time.Hour * 10,
+			availableBank,
+			compostTier: 'compost' as CropUpgradeType
+		});
 
-                if (!prepared.success) {
-                        throw new Error(`Preparation failed: ${prepared.error}`);
-                }
+		if (!prepared.success) {
+			throw new Error(`Preparation failed: ${prepared.error}`);
+		}
 
-                expect(prepared.data.quantity).toBe(1);
-                expect(prepared.data.cost).toStrictEqual(new Bank({ 'Grape seed': 1, Saltpetre: 1 }));
-        });
+		expect(prepared.data.quantity).toBe(1);
+		expect(prepared.data.cost).toStrictEqual(new Bank({ 'Grape seed': 1, Saltpetre: 1 }));
+	});
 });


### PR DESCRIPTION
## Summary
- reformat farming trip helper logic to use repository tab-based indentation
- align the auto farm unit test with project formatting rules

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68d4e66c4ea4832680bcd5bd5877906b