### PR TITLE
Format auto farm test helpers

### DIFF
--- a/tests/unit/autoFarm.test.ts
+++ b/tests/unit/autoFarm.test.ts
@@ -12,9 +12,9 @@ describe('prepareFarmingStep auto farm limits', () => {
 	it('charges only for the achievable quantity when inputs differ', async () => {
 		const user = mockMUser({
 			bank: new Bank({ 'Grape seed': 5, Saltpetre: 1 }),
-			QP: 200
+			QP: 200,
+			skills_farming: convertLVLtoXP(99)
 		});
-		user.user.skills_farming = convertLVLtoXP(99);
 
 		const grapePlant = Farming.Plants.find(plant => plant.name === 'Grape');
 		if (!grapePlant) {

--- a/tests/unit/userutil.ts
+++ b/tests/unit/userutil.ts
@@ -22,6 +22,7 @@ export interface MockUserArgs {
 	meleeGear?: GearSetup | PartialGearSetup;
 	skills_agility?: number;
 	skills_attack?: number;
+	skills_farming?: number;
 	skills_strength?: number;
 	skills_ranged?: number;
 	skills_magic?: number;
@@ -61,7 +62,7 @@ const mockUser = (overrides?: MockUserArgs): User => {
 		skills_prayer: overrides?.skills_prayer ?? 0,
 		skills_fletching: 0,
 		skills_thieving: 0,
-		skills_farming: 0,
+		skills_farming: overrides?.skills_farming ?? 0,
 		skills_herblore: 0,
 		skills_hunter: 0,
 		skills_construction: 0,


### PR DESCRIPTION
## Summary
- format the auto farm unit test to match the repository lint configuration
- format the mock user helper interface and skill initialization to satisfy the linter

## Testing
- pnpm exec biome check tests/unit/userutil.ts tests/unit/autoFarm.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d4e7b559d083268858d31b998b0583