### PR TITLE
Align auto farm scheduling metadata and reserve tree clearing fees

### DIFF
--- a/src/lib/minions/functions/autoFarm.ts
+++ b/src/lib/minions/functions/autoFarm.ts
@@ -148,7 +148,7 @@ export async function autoFarm(
 		const inserted = await prisma.farmedCrop.create({
 			data: {
 				user_id: user.id,
-				date_planted: new Date(),
+				date_planted: new Date(planningStartTime + accumulatedDuration),
 				item_id: step.plant.id,
 				quantity_planted: step.quantity,
 				was_autofarmed: true,

--- a/src/lib/skilling/functions/calcsFarming.ts
+++ b/src/lib/skilling/functions/calcsFarming.ts
@@ -29,7 +29,7 @@ export function calcNumOfPatches(plant: Plant, user: MUser, qp: number): [number
 		}
 	}
 
-	if (user.user.finished_quest_ids.includes(QuestID.ChildrenOfTheSun)) {
+	if (user.user.finished_quest_ids?.includes(QuestID.ChildrenOfTheSun)) {
 		switch (plant.seedType) {
 			case 'allotment':
 				numOfPatches += 2;

--- a/src/mahoji/lib/abstracted_commands/farmingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingCommand.ts
@@ -53,8 +53,10 @@ export async function harvestCommand({
 		return `Please come back when your crops have finished growing in ${formatDuration(patch.readyIn!)}!`;
 	}
 
-	const treeStr = !plant ? null : treeCheck(plant, currentWoodcuttingLevel, GP, patch.lastQuantity);
-	if (treeStr) return treeStr;
+	const treeCheckResult = !plant
+		? { error: null, fee: 0 }
+		: treeCheck(plant, currentWoodcuttingLevel, GP, patch.lastQuantity);
+	if (treeCheckResult.error) return treeCheckResult.error;
 
 	const timePerPatchTravel = Time.Second * plant.timePerPatchTravel;
 	const timePerPatchHarvest = Time.Second * plant.timePerHarvest;
@@ -208,7 +210,7 @@ export async function farmingPlantCommand({
 	const inserted = await prisma.farmedCrop.create({
 		data: {
 			user_id: user.id,
-			date_planted: new Date(),
+			date_planted: new Date(currentDate),
 			item_id: plant.id,
 			quantity_planted: quantity,
 			was_autofarmed: autoFarmed,


### PR DESCRIPTION
## Summary
- ensure auto farm persists planned crops with the scheduled start times and manual plant flows do the same
- reserve the coins required to hire farmers to chop trees during auto farming, and avoid diary lookups when the database client is unavailable
- harden quest-based patch calculations and update harvesting flows to use the richer tree checking result

## Testing
- pnpm test:unit
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68d4ec2625c083268f0c52d0c288d72e