### PR TITLE
Improve per-hour RNG accuracy and add farming regression test

### DIFF
--- a/src/lib/util/rng.ts
+++ b/src/lib/util/rng.ts
@@ -73,11 +73,28 @@ export function perHourChance(
 	oneInXPerHourChance: number,
 	successFunction: () => unknown
 ) {
-	const minutesPassed = Math.floor(durationMilliseconds / 60_000);
-	const perMinuteChance = oneInXPerHourChance * 60;
+	if (durationMilliseconds <= 0 || oneInXPerHourChance <= 0) {
+		return;
+	}
 
-	for (let i = 0; i < minutesPassed; i++) {
-		if (roll(perMinuteChance)) {
+	const hoursPassed = durationMilliseconds / 3_600_000;
+	if (hoursPassed <= 0) {
+		return;
+	}
+
+	const chancePerHour = Math.min(1, 1 / oneInXPerHourChance);
+	const wholeHours = Math.floor(hoursPassed);
+	const remainingHours = hoursPassed - wholeHours;
+
+	for (let i = 0; i < wholeHours; i++) {
+		if (randFloat(0, 1) < chancePerHour) {
+			successFunction();
+		}
+	}
+
+	if (remainingHours > 0) {
+		const remainderChance = chancePerHour >= 1 ? 1 : 1 - Math.pow(1 - chancePerHour, remainingHours);
+		if (randFloat(0, 1) < remainderChance) {
 			successFunction();
 		}
 	}

--- a/tests/unit/autoFarm.test.ts
+++ b/tests/unit/autoFarm.test.ts
@@ -55,4 +55,50 @@ describe('prepareFarmingStep auto farm limits', () => {
 		expect(prepared.data.quantity).toBe(1);
 		expect(prepared.data.cost).toStrictEqual(new Bank({ 'Grape seed': 1, Saltpetre: 1 }));
 	});
+
+	it('requires the tree removal fee when lacking Woodcutting level', async () => {
+		const user = mockMUser({
+			bank: new Bank({ 'Redwood tree seed': 1 }),
+			QP: 200,
+			skills_farming: convertLVLtoXP(99)
+		});
+
+		const redwoodPlant = Farming.Plants.find(plant => plant.name === 'Redwood tree');
+		if (!redwoodPlant) {
+			throw new Error('Expected redwood plant data');
+		}
+
+		const patchDetailed: IPatchDataDetailed = {
+			ready: true,
+			readyIn: null,
+			readyAt: null,
+			patchName: 'redwood',
+			friendlyName: 'Redwood patch',
+			plant: null,
+			lastPlanted: redwoodPlant.name,
+			patchPlanted: true,
+			plantTime: Date.now(),
+			lastQuantity: 1,
+			lastUpgradeType: null,
+			lastPayment: false
+		};
+
+		const availableBank = new Bank({ 'Redwood tree seed': 1, Coins: 1999 });
+		const prepared = await prepareFarmingStep({
+			user,
+			plant: redwoodPlant,
+			quantity: 1,
+			pay: false,
+			patchDetailed,
+			maxTripLength: Time.Hour,
+			availableBank,
+			compostTier: 'ultracompost' as CropUpgradeType
+		});
+
+		expect(prepared.success).toBe(false);
+		if (prepared.success) return;
+		expect(prepared.error).toBe(
+			'Your minion does not have 90 Woodcutting or the 2000 GP required to be able to harvest the currently planted trees, and so they cannot harvest them.'
+		);
+	});
 });

--- a/tests/unit/rng.test.ts
+++ b/tests/unit/rng.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import * as rng from '../../src/lib/util/rng.js';
+
+describe('perHourChance', () => {
+	it('fires for partial hours when the random roll is below the threshold', () => {
+		const callback = vi.fn();
+		const randFloatSpy = vi.spyOn(rng, 'randFloat').mockReturnValue(0);
+
+		rng.perHourChance(30 * 60 * 1000, 2, callback);
+
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(randFloatSpy).toHaveBeenCalledTimes(1);
+
+		randFloatSpy.mockRestore();
+	});
+
+	it('rolls once per full hour and once for the remainder', () => {
+		const callback = vi.fn();
+		const randFloatSpy = vi.spyOn(rng, 'randFloat').mockReturnValueOnce(0.4).mockReturnValueOnce(0.6);
+
+		rng.perHourChance(90 * 60 * 1000, 2, callback);
+
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(randFloatSpy).toHaveBeenCalledTimes(2);
+
+		randFloatSpy.mockRestore();
+	});
+
+	it('ignores invalid durations or chances', () => {
+		const callback = vi.fn();
+		const randFloatSpy = vi.spyOn(rng, 'randFloat');
+
+		rng.perHourChance(0, 2, callback);
+		rng.perHourChance(1000, 0, callback);
+
+		expect(callback).not.toHaveBeenCalled();
+		expect(randFloatSpy).not.toHaveBeenCalled();
+
+		randFloatSpy.mockRestore();
+	});
+});


### PR DESCRIPTION
## Summary
- refine `perHourChance` to operate on hour-based rolls with fractional time support so short trips and high-probability events fire correctly
- add unit coverage for the new `perHourChance` behaviour and for rejecting redwood harvests when the minion can’t afford the tree removal fee

## Testing
- `pnpm test --filter rng` *(fails: vite cannot resolve the oldschooljs package in this environment)*
- `pnpm vitest run --config vitest.unit.config.mts tests/unit/rng.test.ts tests/unit/autoFarm.test.ts` *(fails: vite cannot resolve the oldschooljs package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f45a9b6c8326bda32521f82fdb70