### PR TITLE
chore: format and lint branch

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -21,6 +21,8 @@ declare global {
 
 	type CommandResponse = Promise<null | string | InteractionReplyOptions>;
 
+	type MUser = import('./lib/MUser.js').MUser;
+
 	interface OSBMahojiCommand extends ICommand {
 		attributes?: Omit<AbstractCommandAttributes, 'description'>;
 	}

--- a/src/lib/MUser.ts
+++ b/src/lib/MUser.ts
@@ -95,7 +95,7 @@ function alchPrice(bank: Bank, item: Item, tripLength: number, agility?: boolean
 }
 
 export type SelectedUserStats<T extends Prisma.UserStatsSelect> = {
-        [K in keyof T]: K extends keyof UserStats ? UserStats[K] : never;
+	[K in keyof T]: K extends keyof UserStats ? UserStats[K] : never;
 };
 
 export type MUser = MUserClass;
@@ -1021,7 +1021,6 @@ Charge your items using ${mentionCommand(globalClient, 'minion', 'charge')}.`
 	}
 }
 declare global {
-	export type MUser = MUserClass;
 	var mUserFetch: typeof srcMUserFetch;
 	var GlobalMUserClass: typeof MUserClass;
 }

--- a/tests/unit/autoFarm.integration.test.ts
+++ b/tests/unit/autoFarm.integration.test.ts
@@ -39,17 +39,17 @@ interface AutoFarmStubOptions {
 }
 
 function createAutoFarmStub({ gp, farmingLevel, woodcuttingLevel, bank }: AutoFarmStubOptions) {
-        const bankState = bank.clone();
+	const bankState = bank.clone();
 	const emptyGearSetup = {
 		hasEquipped: vi.fn().mockReturnValue(false),
 		equippedWeapon: vi.fn().mockReturnValue({ name: '' })
 	} as const;
-        const user = {
-                id: '1',
-                user: {
-                        id: '1',
-                        GP: gp,
-                        bank: bankState.toJSON(),
+	const user = {
+		id: '1',
+		user: {
+			id: '1',
+			GP: gp,
+			bank: bankState.toJSON(),
 			minion_defaultPay: false,
 			minion_defaultCompostToUse: null,
 			completed_ca_task_ids: []
@@ -146,8 +146,8 @@ function createAutoFarmStub({ gp, farmingLevel, woodcuttingLevel, bank }: AutoFa
 					user.GP -= coins;
 					removal.remove('Coins', coins);
 				}
-                                bankState.remove(removal);
-                                user.user.bank = bankState.toJSON();
+				bankState.remove(removal);
+				user.user.bank = bankState.toJSON();
 			}
 			return { newUser: user.user };
 		}),
@@ -168,9 +168,9 @@ function createAutoFarmStub({ gp, farmingLevel, woodcuttingLevel, bank }: AutoFa
 		perkTier: vi.fn().mockReturnValue(0),
 		hasSkillReqs: vi.fn().mockReturnValue([true, null]),
 		getAttackStyles: vi.fn().mockReturnValue([]),
-                update: vi.fn().mockResolvedValue(undefined)
-        } as any;
-        return user as MUser;
+		update: vi.fn().mockResolvedValue(undefined)
+	} as any;
+	return user as MUser;
 }
 
 describe('autoFarm tree clearing fees', () => {
@@ -224,9 +224,9 @@ describe('autoFarm tree clearing fees', () => {
 			}
 		];
 
-                const patches: Partial<Record<FarmingPatchName, IPatchData>> = {
-                        [basePatch.patchName]: {
-                                lastPlanted: basePatch.lastPlanted,
+		const patches: Partial<Record<FarmingPatchName, IPatchData>> = {
+			[basePatch.patchName]: {
+				lastPlanted: basePatch.lastPlanted,
 				patchPlanted: basePatch.patchPlanted,
 				plantTime: basePatch.plantTime,
 				lastQuantity: basePatch.lastQuantity,
@@ -235,12 +235,7 @@ describe('autoFarm tree clearing fees', () => {
 			}
 		};
 
-                const response = await autoFarm(
-                        user,
-                        patchesDetailed,
-                        patches as Record<FarmingPatchName, IPatchData>,
-                        '123'
-                );
+		const response = await autoFarm(user, patchesDetailed, patches as Record<FarmingPatchName, IPatchData>, '123');
 
 		expect(response).toContain('auto farming');
 		expect(user.user.GP).toBe(3000);

--- a/tests/unit/farmingActivity.test.ts
+++ b/tests/unit/farmingActivity.test.ts
@@ -172,10 +172,10 @@ function createStubUser({ gp, farmingLevel, woodcuttingLevel }: StubUserOptions)
 }
 
 describe('tree clearing fees', () => {
-        const redwoodPlant = Farming.Plants.find(plant => plant.name === 'Redwood tree');
-        if (!redwoodPlant) {
-                throw new Error('Expected redwood plant data');
-        }
+	const redwoodPlant = Farming.Plants.find(plant => plant.name === 'Redwood tree');
+	if (!redwoodPlant) {
+		throw new Error('Expected redwood plant data');
+	}
 
 	const basePatch: IPatchDataDetailed = {
 		ready: true,
@@ -192,36 +192,36 @@ describe('tree clearing fees', () => {
 		lastPayment: false
 	};
 
-        const mutableGlobal = globalThis as any;
-        let originalMUserFetch = mutableGlobal.mUserFetch;
+	const mutableGlobal = globalThis as any;
+	let originalMUserFetch = mutableGlobal.mUserFetch;
 
-        beforeEach(() => {
-                vi.restoreAllMocks();
-                originalMUserFetch = mutableGlobal.mUserFetch;
-                mutableGlobal.globalClient = { emit: vi.fn(), channels: { cache: new Map() } };
-                mutableGlobal.prisma = {
-                        clientStorage: {
-                                findFirst: vi.fn().mockResolvedValue({ id: '1', farming_loot_bank: {} }),
-                                update: vi.fn().mockResolvedValue({ id: '1' })
-                        },
-                        farmedCrop: {
-                                update: vi.fn().mockResolvedValue(undefined)
-                        },
-                        userStats: {
-                                update: vi.fn().mockResolvedValue({})
-                        }
-                };
-        });
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		originalMUserFetch = mutableGlobal.mUserFetch;
+		mutableGlobal.globalClient = { emit: vi.fn(), channels: { cache: new Map() } };
+		mutableGlobal.prisma = {
+			clientStorage: {
+				findFirst: vi.fn().mockResolvedValue({ id: '1', farming_loot_bank: {} }),
+				update: vi.fn().mockResolvedValue({ id: '1' })
+			},
+			farmedCrop: {
+				update: vi.fn().mockResolvedValue(undefined)
+			},
+			userStats: {
+				update: vi.fn().mockResolvedValue({})
+			}
+		};
+	});
 
-        afterEach(() => {
-                mutableGlobal.prisma = undefined;
-                mutableGlobal.globalClient = undefined;
-                mutableGlobal.mUserFetch = originalMUserFetch;
-        });
+	afterEach(() => {
+		mutableGlobal.prisma = undefined;
+		mutableGlobal.globalClient = undefined;
+		mutableGlobal.mUserFetch = originalMUserFetch;
+	});
 
 	it('only removes the tree clearing fee once during manual replant', async () => {
 		const user = createStubUser({ gp: 5000, farmingLevel: 99, woodcuttingLevel: 1 });
-                mutableGlobal.mUserFetch = vi.fn().mockResolvedValue(user);
+		mutableGlobal.mUserFetch = vi.fn().mockResolvedValue(user);
 
 		const prepared = await prepareFarmingStep({
 			user: user as unknown as MUser,
@@ -246,34 +246,34 @@ describe('tree clearing fees', () => {
 		const removeSpy = vi.spyOn(user, 'removeItemsFromBank');
 		vi.spyOn(Math, 'random').mockReturnValue(1);
 
-                const task: FarmingActivityTaskOptions = {
-                        id: 1,
-                        type: 'Farming',
-                        userID: user.id,
-                        channelID: '123',
-                        plantsName: redwoodPlant.name,
-                        quantity: 1,
+		const task: FarmingActivityTaskOptions = {
+			id: 1,
+			type: 'Farming',
+			userID: user.id,
+			channelID: '123',
+			plantsName: redwoodPlant.name,
+			quantity: 1,
 			upgradeType: null,
 			payment: false,
 			treeChopFeePaid: treeFee,
-                        patchType: {
-                                lastPlanted: basePatch.lastPlanted,
-                                patchPlanted: true,
-                                plantTime: basePatch.plantTime,
-                                lastQuantity: basePatch.lastQuantity,
-                                lastUpgradeType: null,
-                                lastPayment: false
-                        },
-                        planting: true,
-                        currentDate: Date.now(),
-                        finishDate: Date.now() + Time.Minute * 5,
-                        duration: Time.Minute * 5,
-                        autoFarmed: false
-                };
+			patchType: {
+				lastPlanted: basePatch.lastPlanted,
+				patchPlanted: true,
+				plantTime: basePatch.plantTime,
+				lastQuantity: basePatch.lastQuantity,
+				lastUpgradeType: null,
+				lastPayment: false
+			},
+			planting: true,
+			currentDate: Date.now(),
+			finishDate: Date.now() + Time.Minute * 5,
+			duration: Time.Minute * 5,
+			autoFarmed: false
+		};
 
-                await (farmingTask.run as (data: FarmingActivityTaskOptions) => Promise<void>)(task);
+		await (farmingTask.run as (data: FarmingActivityTaskOptions) => Promise<void>)(task);
 
-                expect(removeSpy).not.toHaveBeenCalled();
-                expect(user.user.GP).toBe(5000 - treeFee);
-        });
+		expect(removeSpy).not.toHaveBeenCalled();
+		expect(user.user.GP).toBe(5000 - treeFee);
+	});
 });


### PR DESCRIPTION
## Summary
- run the repository formatting commands to update JSON, Prisma, and source files
- add a global ambient MUser type definition so the linter no longer reports a redeclaration in MUser.ts

## Testing
- pnpm exec prettier --use-tabs --write "**/*.json"
- pnpm exec prettier --use-tabs --write "**/*.{yaml,yml,css,html}"
- pnpm exec prisma format --schema ./prisma/robochimp.prisma
- pnpm exec prisma format --schema ./prisma/schema.prisma
- pnpm exec biome check --write --unsafe --diagnostic-level=error
- pnpm exec biome check --diagnostic-level=error

------
https://chatgpt.com/codex/tasks/task_e_68d53a3f634c8326b15d9d2469adf94d