### PR TITLE
Fix farming activity test mocks

### DIFF
--- a/tests/unit/farmingActivity.test.ts
+++ b/tests/unit/farmingActivity.test.ts
@@ -11,23 +11,23 @@ import { SkillsEnum } from '../../src/lib/skilling/types.js';
 import type { FarmingActivityTaskOptions } from '../../src/lib/types/minions.js';
 import { farmingTask } from '../../src/tasks/minions/farmingActivity.js';
 
-vi.mock('../../src/lib/util/handleTripFinish.js', () => ({
-	handleTripFinish: vi.fn()
+vi.mock('@/lib/util/handleTripFinish.js', () => ({
+        handleTripFinish: vi.fn()
 }));
-vi.mock('../../src/lib/util/updateBankSetting.js', () => ({
-	updateBankSetting: vi.fn()
+vi.mock('@/lib/util/updateBankSetting.js', () => ({
+        updateBankSetting: vi.fn()
 }));
-vi.mock('../../src/lib/util/addSubTaskToActivityTask.js', () => ({
-	default: vi.fn()
+vi.mock('@/lib/util/addSubTaskToActivityTask.js', () => ({
+        default: vi.fn()
 }));
-vi.mock('../../src/lib/util/webhook.js', () => ({
-	sendToChannelID: vi.fn()
+vi.mock('@/lib/util/webhook.js', () => ({
+        sendToChannelID: vi.fn()
 }));
-vi.mock('../../src/lib/combat_achievements/combatAchievements.js', () => ({
-	combatAchievementTripEffect: vi.fn().mockResolvedValue(null)
+vi.mock('@/lib/combat_achievements/combatAchievements.js', () => ({
+        combatAchievementTripEffect: vi.fn().mockResolvedValue(null)
 }));
-vi.mock('../../src/lib/canvas/chatHeadImage.js', () => ({
-	default: vi.fn()
+vi.mock('@/lib/canvas/chatHeadImage.js', () => ({
+        default: vi.fn()
 }));
 vi.mock('@/mahoji/mahojiSettings.js', () => ({
 	userStatsBankUpdate: vi.fn(),


### PR DESCRIPTION
## Summary
- align farming activity unit test mocks with the module paths used in production so Vitest stubs the correct files
- restore the webhook resolver to its prior behaviour now that the test no longer imports the real module

## Testing
- `pnpm vitest run --config vitest.unit.config.mts tests/unit/farmingActivity.test.ts` *(fails: Failed to resolve entry for package "oldschooljs" in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5476b811883268d79a875de5a5df4