### PR TITLE
test: mock oldschooljs dependencies in farming test

### DIFF
--- a/tests/unit/farmingActivity.test.ts
+++ b/tests/unit/farmingActivity.test.ts
@@ -1,7 +1,232 @@
+const { FakeBank, diaryStub } = vi.hoisted(() => {
+	class FakeBank {
+		private data: Map<string, number>;
+		private frozen = false;
+
+		constructor(initial?: FakeBank | Record<string | number, number>) {
+			this.data = new Map();
+			if (!initial) {
+				return;
+			}
+			if (initial instanceof FakeBank) {
+				this.data = new Map(initial.data);
+				return;
+			}
+			for (const [rawKey, rawQty] of Object.entries(initial)) {
+				const qty = Number(rawQty);
+				if (!Number.isFinite(qty) || qty <= 0) continue;
+				this.data.set(this.normalize(rawKey), qty);
+			}
+		}
+
+		private normalize(item: unknown): string {
+			if (typeof item === 'number') return item.toString();
+			if (typeof item === 'string') return item;
+			if (item && typeof item === 'object') {
+				const candidate = item as { id?: unknown; name?: unknown };
+				if (candidate.id !== undefined) return this.normalize(candidate.id);
+				if (candidate.name !== undefined) return this.normalize(candidate.name);
+			}
+			throw new Error(`Unsupported bank item: ${String(item)}`);
+		}
+
+		private assertMutable() {
+			if (this.frozen) throw new Error('Tried to mutate a frozen Bank.');
+		}
+
+		private setQuantity(key: string, quantity: number) {
+			if (quantity <= 0) {
+				this.data.delete(key);
+				return;
+			}
+			this.data.set(key, quantity);
+		}
+
+		add(item: unknown, quantity = 1): this {
+			if (item instanceof FakeBank) {
+				this.assertMutable();
+				for (const [key, qty] of item.data.entries()) {
+					this.setQuantity(key, (this.data.get(key) ?? 0) + qty);
+				}
+				return this;
+			}
+			if (quantity <= 0) return this;
+			this.assertMutable();
+			const key = this.normalize(item);
+			this.setQuantity(key, (this.data.get(key) ?? 0) + quantity);
+			return this;
+		}
+
+		amount(item: unknown): number {
+			const key = this.normalize(item);
+			return this.data.get(key) ?? 0;
+		}
+
+		has(other: FakeBank | Record<string | number, number>): boolean {
+			const otherBank = other instanceof FakeBank ? other : new FakeBank(other);
+			for (const [key, qty] of otherBank.data.entries()) {
+				if ((this.data.get(key) ?? 0) < qty) return false;
+			}
+			return true;
+		}
+
+		clone(): FakeBank {
+			return new FakeBank(this);
+		}
+
+		multiply(multiplier: number): this {
+			this.assertMutable();
+			for (const [key, qty] of Array.from(this.data.entries())) {
+				this.setQuantity(key, qty * multiplier);
+			}
+			return this;
+		}
+
+		items(): [{ id: string; name: string }, number][] {
+			return Array.from(this.data.entries())
+				.filter(([, qty]) => qty > 0)
+				.map(([key, qty]) => [{ id: key, name: key }, qty]);
+		}
+
+		toString(): string {
+			const parts = this.items().map(([item, qty]) => `${qty.toLocaleString()}x ${item.name}`);
+			return parts.length > 0 ? parts.join(', ') : 'No items';
+		}
+
+		toJSON(): Record<string, number> {
+			return Object.fromEntries(this.data.entries());
+		}
+
+		freeze(): this {
+			this.frozen = true;
+			return this;
+		}
+
+		get length(): number {
+			return this.data.size;
+		}
+	}
+
+	const diary = {
+		name: 'Ardougne Diary',
+		elite: { name: 'Elite' }
+	};
+
+	return { FakeBank, diaryStub: diary };
+});
+
+vi.mock(
+	'oldschooljs',
+	() => {
+		const Monsters = {
+			Hespori: {
+				id: 0,
+				kill: vi.fn(() => new FakeBank())
+			}
+		};
+		const convertXPtoLVL = (xp: number) => {
+			if (!Number.isFinite(xp) || xp <= 0) return 1;
+			return Math.max(1, Math.min(120, Math.floor(xp / 100_000) + 1));
+		};
+		const calcCombatLevel = () => 3;
+		return {
+			__esModule: true,
+			Bank: FakeBank,
+			Monsters,
+			convertXPtoLVL,
+			calcCombatLevel,
+			convertLVLtoXP: () => 0
+		};
+	},
+	{ virtual: true }
+);
+
+vi.mock('@/lib/diaries.js', () => ({
+	__esModule: true,
+	ArdougneDiary: diaryStub,
+	userhasDiaryTier: vi.fn().mockResolvedValue([false, '', diaryStub])
+}));
+
+vi.mock('@/lib/skilling/skills/farming/index.js', () => {
+	const redwoodPlant = {
+		id: 29668,
+		level: 90,
+		plantXp: 230,
+		checkXp: 22_450,
+		harvestXp: 0,
+		inputItems: new FakeBank({ 'Redwood tree seed': 1 }).freeze(),
+		outputLogs: 'Redwood logs',
+		treeWoodcuttingLevel: 90,
+		name: 'Redwood tree',
+		aliases: ['redwood tree', 'redwood'],
+		petChance: 5000,
+		seedType: 'redwood',
+		growthTime: 6400,
+		numOfStages: 11,
+		chance1: 0,
+		chance99: 0,
+		chanceOfDeath: 8,
+		protectionPayment: new FakeBank({ Dragonfruit: 6 }).freeze(),
+		woodcuttingXp: 380,
+		needsChopForHarvest: true,
+		fixedOutput: false,
+		givesLogs: true,
+		givesCrops: false,
+		defaultNumOfPatches: 0,
+		canPayFarmer: true,
+		canCompostPatch: true,
+		canCompostandPay: false,
+		additionalPatchesByQP: [] as Array<[number, number]>,
+		additionalPatchesByFarmLvl: [] as Array<[number, number]>,
+		additionalPatchesByFarmGuildAndLvl: [[85, 1]] as Array<[number, number]>,
+		timePerPatchTravel: 10,
+		timePerHarvest: 15
+	};
+	const Farming = {
+		aliases: ['farming'],
+		Plants: [redwoodPlant],
+		maleFarmerItems: {},
+		femaleFarmerItems: {},
+		name: 'Farming'
+	};
+	return {
+		__esModule: true,
+		default: Farming
+	};
+});
+
+vi.mock('@/lib/util/handleTripFinish.js', () => ({
+	__esModule: true,
+	handleTripFinish: vi.fn()
+}));
+vi.mock('@/lib/util/updateBankSetting.js', () => ({
+	__esModule: true,
+	updateBankSetting: vi.fn()
+}));
+vi.mock('@/lib/util/addSubTaskToActivityTask.js', () => ({
+	__esModule: true,
+	default: vi.fn()
+}));
+vi.mock('@/lib/util/webhook.js', () => ({
+	__esModule: true,
+	sendToChannelID: vi.fn()
+}));
+vi.mock('@/lib/combat_achievements/combatAchievements.js', () => ({
+	__esModule: true,
+	combatAchievementTripEffect: vi.fn().mockResolvedValue(null)
+}));
+vi.mock('@/lib/canvas/chatHeadImage.js', () => ({
+	__esModule: true,
+	default: vi.fn()
+}));
+vi.mock('@/mahoji/mahojiSettings.js', () => ({
+	__esModule: true,
+	userStatsBankUpdate: vi.fn(),
+	userHasGracefulEquipped: vi.fn().mockReturnValue(false)
+}));
+
 import { Time } from '@oldschoolgg/toolkit/datetime';
 import type { CropUpgradeType } from '@prisma/client';
-import { Bank } from 'oldschooljs';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { MUser } from '../../src/lib/MUser.js';
 import type { IPatchDataDetailed } from '../../src/lib/minions/farming/types.js';
@@ -11,28 +236,7 @@ import { SkillsEnum } from '../../src/lib/skilling/types.js';
 import type { FarmingActivityTaskOptions } from '../../src/lib/types/minions.js';
 import { farmingTask } from '../../src/tasks/minions/farmingActivity.js';
 
-vi.mock('@/lib/util/handleTripFinish.js', () => ({
-	handleTripFinish: vi.fn()
-}));
-vi.mock('@/lib/util/updateBankSetting.js', () => ({
-	updateBankSetting: vi.fn()
-}));
-vi.mock('@/lib/util/addSubTaskToActivityTask.js', () => ({
-	default: vi.fn()
-}));
-vi.mock('@/lib/util/webhook.js', () => ({
-	sendToChannelID: vi.fn()
-}));
-vi.mock('@/lib/combat_achievements/combatAchievements.js', () => ({
-	combatAchievementTripEffect: vi.fn().mockResolvedValue(null)
-}));
-vi.mock('@/lib/canvas/chatHeadImage.js', () => ({
-	default: vi.fn()
-}));
-vi.mock('@/mahoji/mahojiSettings.js', () => ({
-	userStatsBankUpdate: vi.fn(),
-	userHasGracefulEquipped: vi.fn().mockReturnValue(false)
-}));
+const Bank = FakeBank;
 
 interface StubUserOptions {
 	gp: number;


### PR DESCRIPTION
## Summary
- replace the farming activity unit test imports with a hoisted FakeBank implementation and virtual `oldschooljs` mock so the test no longer requires the real package build
- stub the farming data and diary helpers that depend on `oldschooljs` to keep the scenario self-contained for the tree clearing fee assertion

## Testing
- pnpm test:lint *(pass)*
- pnpm test:unit *(fails: existing Vitest runner cannot resolve the `oldschooljs` workspace package)*


------
https://chatgpt.com/codex/tasks/task_e_68d554068f84832687adf94a58e5f91c