### PR TITLE
Fix tree clearing fee planning logic

### DIFF
--- a/src/lib/minions/functions/farmingTripHelpers.ts
+++ b/src/lib/minions/functions/farmingTripHelpers.ts
@@ -8,6 +8,7 @@ import type { IPatchDataDetailed } from '@/lib/minions/farming/types.js';
 import { calcNumOfPatches } from '@/lib/skilling/functions/calcsFarming.js';
 import type { Plant } from '@/lib/skilling/types.js';
 import { SkillsEnum } from '@/lib/skilling/types.js';
+import { findPlant } from '@/lib/util/farmingHelpers.js';
 import { userHasGracefulEquipped } from '@/mahoji/mahojiSettings.js';
 
 export interface PrepareFarmingStepOptions {
@@ -78,8 +79,8 @@ export async function prepareFarmingStep({
 	const currentWoodcuttingLevel = user.skillLevel(SkillsEnum.Woodcutting);
 
 	let treeChopCost = 0;
-	if (patchDetailed.patchPlanted && patchDetailed.lastPlanted) {
-		const plantedPlant = plant.name === patchDetailed.lastPlanted ? plant : null;
+	if (patchDetailed.patchPlanted) {
+		const plantedPlant = patchDetailed.plant ?? findPlant(patchDetailed.lastPlanted);
 		if (plantedPlant) {
 			const { error: treeError, fee } = treeCheck(
 				plantedPlant,


### PR DESCRIPTION
## Summary
- ensure prepareFarmingStep bases the tree-removal fee on the currently planted crop so GP is reserved when swapping seeds
- format the auto farm integration spec to satisfy Biome's tab-based indentation rules

## Testing
- `pnpm test:lint`
- `pnpm vitest run --config vitest.unit.config.mts tests/unit/autoFarm.integration.test.ts` *(fails: vitest cannot resolve the workspace package "oldschooljs" during import analysis)*

------
https://chatgpt.com/codex/tasks/task_e_68d55f7b46a483268ae75c7c6030d21d