### PR TITLE
Fix auto farm test stub to avoid read-only assignment

### DIFF
--- a/tests/unit/autoFarm.integration.test.ts
+++ b/tests/unit/autoFarm.integration.test.ts
@@ -265,7 +265,7 @@ describe('autoFarm tree clearing fees', () => {
 			gp: 1000,
 			farmingLevel: 99,
 			woodcuttingLevel: 1,
-			bank: new Bank({ 'Yew seed': 1 }),
+			bank: new Bank({ 'Yew seed': 10 }),
 			autoFarmFilter: AutoFarmFilterEnum.AllFarm
 		});
 

--- a/tests/unit/autoFarm.integration.test.ts
+++ b/tests/unit/autoFarm.integration.test.ts
@@ -32,38 +32,44 @@ vi.mock('../../src/lib/util/calcMaxTripLength.js', () => ({
 }));
 
 interface AutoFarmStubOptions {
-        gp: number;
-        farmingLevel: number;
-        woodcuttingLevel: number;
-        bank: Bank;
-        autoFarmFilter?: AutoFarmFilterEnum;
+	gp: number;
+	farmingLevel: number;
+	woodcuttingLevel: number;
+	bank: Bank;
+	autoFarmFilter?: AutoFarmFilterEnum;
 }
 
-function createAutoFarmStub({ gp, farmingLevel, woodcuttingLevel, bank, autoFarmFilter = AutoFarmFilterEnum.Replant }: AutoFarmStubOptions) {
-        const bankState = bank.clone();
-        const emptyGearSetup = {
-                hasEquipped: vi.fn().mockReturnValue(false),
-                equippedWeapon: vi.fn().mockReturnValue({ name: '' })
-        } as const;
-        const user = {
-                id: '1',
-                user: {
-                        id: '1',
-                        GP: gp,
-                        bank: bankState.toJSON(),
-                        auto_farm_filter: autoFarmFilter,
-                        minion_defaultPay: false,
-                        minion_defaultCompostToUse: null,
-                        completed_ca_task_ids: []
-                },
-                bank: bankState,
-                cl: new Bank(),
-                GP: gp,
-                minionName: 'Stub Minion',
-                minionIsBusy: false,
-                get autoFarmFilter() {
-                        return this.user.auto_farm_filter;
-                },
+function createAutoFarmStub({
+	gp,
+	farmingLevel,
+	woodcuttingLevel,
+	bank,
+	autoFarmFilter = AutoFarmFilterEnum.Replant
+}: AutoFarmStubOptions) {
+	const bankState = bank.clone();
+	const emptyGearSetup = {
+		hasEquipped: vi.fn().mockReturnValue(false),
+		equippedWeapon: vi.fn().mockReturnValue({ name: '' })
+	} as const;
+	const user = {
+		id: '1',
+		user: {
+			id: '1',
+			GP: gp,
+			bank: bankState.toJSON(),
+			auto_farm_filter: autoFarmFilter,
+			minion_defaultPay: false,
+			minion_defaultCompostToUse: null,
+			completed_ca_task_ids: []
+		},
+		bank: bankState,
+		cl: new Bank(),
+		GP: gp,
+		minionName: 'Stub Minion',
+		minionIsBusy: false,
+		get autoFarmFilter() {
+			return this.user.auto_farm_filter;
+		},
 		QP: 200,
 		bitfield: [] as number[],
 		toString() {
@@ -255,13 +261,13 @@ describe('autoFarm tree clearing fees', () => {
 			throw new Error('Expected magic and yew plant data');
 		}
 
-                const user = createAutoFarmStub({
-                        gp: 1000,
-                        farmingLevel: 99,
-                        woodcuttingLevel: 1,
-                        bank: new Bank({ 'Yew tree seed': 1 }),
-                        autoFarmFilter: AutoFarmFilterEnum.AllFarm
-                });
+		const user = createAutoFarmStub({
+			gp: 1000,
+			farmingLevel: 99,
+			woodcuttingLevel: 1,
+			bank: new Bank({ 'Yew tree seed': 1 }),
+			autoFarmFilter: AutoFarmFilterEnum.AllFarm
+		});
 
 		const patchName = magicPlant.seedType as FarmingPatchName;
 		const patchesDetailed: IPatchDataDetailed[] = [

--- a/tests/unit/autoFarm.integration.test.ts
+++ b/tests/unit/autoFarm.integration.test.ts
@@ -265,7 +265,7 @@ describe('autoFarm tree clearing fees', () => {
 			gp: 1000,
 			farmingLevel: 99,
 			woodcuttingLevel: 1,
-			bank: new Bank({ 'Yew tree seed': 1 }),
+			bank: new Bank({ 'Yew seed': 1 }),
 			autoFarmFilter: AutoFarmFilterEnum.AllFarm
 		});
 

--- a/tests/unit/autoFarm.integration.test.ts
+++ b/tests/unit/autoFarm.integration.test.ts
@@ -32,34 +32,38 @@ vi.mock('../../src/lib/util/calcMaxTripLength.js', () => ({
 }));
 
 interface AutoFarmStubOptions {
-	gp: number;
-	farmingLevel: number;
-	woodcuttingLevel: number;
-	bank: Bank;
+        gp: number;
+        farmingLevel: number;
+        woodcuttingLevel: number;
+        bank: Bank;
+        autoFarmFilter?: AutoFarmFilterEnum;
 }
 
-function createAutoFarmStub({ gp, farmingLevel, woodcuttingLevel, bank }: AutoFarmStubOptions) {
-	const bankState = bank.clone();
-	const emptyGearSetup = {
-		hasEquipped: vi.fn().mockReturnValue(false),
-		equippedWeapon: vi.fn().mockReturnValue({ name: '' })
-	} as const;
-	const user = {
-		id: '1',
-		user: {
-			id: '1',
-			GP: gp,
-			bank: bankState.toJSON(),
-			minion_defaultPay: false,
-			minion_defaultCompostToUse: null,
-			completed_ca_task_ids: []
-		},
-		bank: bankState,
-		cl: new Bank(),
-		GP: gp,
-		minionName: 'Stub Minion',
-		minionIsBusy: false,
-		autoFarmFilter: AutoFarmFilterEnum.Replant,
+function createAutoFarmStub({ gp, farmingLevel, woodcuttingLevel, bank, autoFarmFilter = AutoFarmFilterEnum.Replant }: AutoFarmStubOptions) {
+        const bankState = bank.clone();
+        const emptyGearSetup = {
+                hasEquipped: vi.fn().mockReturnValue(false),
+                equippedWeapon: vi.fn().mockReturnValue({ name: '' })
+        } as const;
+        const user = {
+                id: '1',
+                user: {
+                        id: '1',
+                        GP: gp,
+                        bank: bankState.toJSON(),
+                        auto_farm_filter: autoFarmFilter,
+                        minion_defaultPay: false,
+                        minion_defaultCompostToUse: null,
+                        completed_ca_task_ids: []
+                },
+                bank: bankState,
+                cl: new Bank(),
+                GP: gp,
+                minionName: 'Stub Minion',
+                minionIsBusy: false,
+                get autoFarmFilter() {
+                        return this.user.auto_farm_filter;
+                },
 		QP: 200,
 		bitfield: [] as number[],
 		toString() {
@@ -251,13 +255,13 @@ describe('autoFarm tree clearing fees', () => {
 			throw new Error('Expected magic and yew plant data');
 		}
 
-		const user = createAutoFarmStub({
-			gp: 1000,
-			farmingLevel: 99,
-			woodcuttingLevel: 1,
-			bank: new Bank({ 'Yew tree seed': 1 })
-		});
-		user.autoFarmFilter = AutoFarmFilterEnum.AllFarm;
+                const user = createAutoFarmStub({
+                        gp: 1000,
+                        farmingLevel: 99,
+                        woodcuttingLevel: 1,
+                        bank: new Bank({ 'Yew tree seed': 1 }),
+                        autoFarmFilter: AutoFarmFilterEnum.AllFarm
+                });
 
 		const patchName = magicPlant.seedType as FarmingPatchName;
 		const patchesDetailed: IPatchDataDetailed[] = [


### PR DESCRIPTION
## Summary
- allow the autofarm test stub to accept an initial filter value
- forward the filter value to the mocked user data and expose it via a getter
- configure the second test case to create the stub with the AllFarm filter

## Testing
- pnpm test:types *(fails: requires workspace dependencies such as @oldschoolgg/toolkit and oldschooljs to be built)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c44a7d948326b1dbb2e10ef3cf29