### PR TITLE
Allow sequential auto farm steps beyond max trip length

### DIFF
--- a/src/lib/minions/functions/autoFarm.ts
+++ b/src/lib/minions/functions/autoFarm.ts
@@ -77,42 +77,42 @@ export async function autoFarm(
 			"There's no Farming crops that you have planted that are ready to be replanted or no seeds remaining.";
 	}
 
-	for (const plant of eligiblePlants) {
-		if (totalDuration >= maxTripLength) {
-			break;
-		}
-		const patchDetailed = patchesDetailed.find(p => p.patchName === plant.seedType);
-		if (!patchDetailed) continue;
-		if (usedPatches.has(patchDetailed.patchName)) continue;
-		if (patchDetailed.ready === false) continue;
+        for (const plant of eligiblePlants) {
+                const patchDetailed = patchesDetailed.find(p => p.patchName === plant.seedType);
+                if (!patchDetailed) continue;
+                if (usedPatches.has(patchDetailed.patchName)) continue;
+                if (patchDetailed.ready === false) continue;
 
-		const remainingTime = maxTripLength - totalDuration;
-		if (remainingTime <= 0) break;
-
-		const prepared = await prepareFarmingStep({
-			user,
-			plant,
-			quantity: null,
-			pay: false,
-			patchDetailed,
-			maxTripLength: remainingTime,
-			availableBank: remainingBank,
-			compostTier
-		});
-		if (!prepared.success) {
+                const prepared = await prepareFarmingStep({
+                        user,
+                        plant,
+                        quantity: null,
+                        pay: false,
+                        patchDetailed,
+                        maxTripLength,
+                        availableBank: remainingBank,
+                        compostTier
+                });
+                if (!prepared.success) {
 			if (!firstPrepareError) {
 				firstPrepareError = prepared.error;
 			}
 			continue;
 		}
 
-		const { quantity, duration, cost, upgradeType, didPay, infoStr, boostStr, treeChopFee } = prepared.data;
-		if (quantity <= 0 || duration <= 0) {
-			continue;
-		}
-		if (!remainingBank.has(cost)) {
-			continue;
-		}
+                const { quantity, duration, cost, upgradeType, didPay, infoStr, boostStr, treeChopFee } = prepared.data;
+                if (quantity <= 0 || duration <= 0) {
+                        continue;
+                }
+                if (duration > maxTripLength) {
+                        if (!firstPrepareError) {
+                                firstPrepareError = `${user.minionName} can't go on trips longer than ${formatDuration(maxTripLength)}.`;
+                        }
+                        continue;
+                }
+                if (!remainingBank.has(cost)) {
+                        continue;
+                }
 
 		if (treeChopFee > 0 && remainingBank.amount('Coins') < treeChopFee) {
 			if (!firstPrepareError) {


### PR DESCRIPTION
## Summary
- pass the full farming trip cap to each prepared step and only skip plans that exceed the per-trip limit
- continue accumulating duration for reporting while allowing additional patches to be scheduled sequentially
- add a regression test ensuring multiple long patches are still planned when their combined duration exceeds the cap

## Testing
- pnpm vitest run --config vitest.unit.config.mts tests/unit/autoFarm.integration.test.ts *(fails: Failed to resolve entry for package "oldschooljs")*


------
https://chatgpt.com/codex/tasks/task_e_68d65fa8e7748326967d1fa1701a1a4e