### PR TITLE
docs: simplify perHourChance comment language

### DIFF
--- a/src/lib/util/rng.ts
+++ b/src/lib/util/rng.ts
@@ -96,6 +96,9 @@ export function perHourChance(
 	while (true) {
 		const randomValue = rand(0, 1);
 		const clamped = Math.min(Math.max(randomValue, Number.EPSILON), 1 - Number.EPSILON);
+		// Turn the uniform random number into the hours we wait before the next roll.
+		// The formula `-log(1 - U) / ratePerHour` is how you get an exponential wait
+		// time for a Poisson process, which is what controls these random events.
 		const waitTime = -Math.log(1 - clamped) / ratePerHour;
 		elapsedHours += waitTime;
 		if (elapsedHours > hoursPassed) {


### PR DESCRIPTION
## Summary
- rewrite the `perHourChance` exponential waiting time comment in plain language
- format the loop so it complies with Biome's expectations

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68d69afab5988326a9a9e5374dbd98a6