### PR TITLE
Fix Ring of endurance boost text casing

### DIFF
--- a/src/mahoji/lib/abstracted_commands/farmingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingCommand.ts
@@ -70,7 +70,7 @@ export async function harvestCommand({
 	}
 
 	if (user.hasEquippedOrInBank(['Ring of endurance'])) {
-		boostStr.push('10% time for Ring of Endurance');
+		boostStr.push('10% time for Ring of endurance');
 		duration *= 0.9;
 	}
 


### PR DESCRIPTION
## Summary
- adjust the manual farming harvest boost string to match the Ring of endurance casing used elsewhere

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6a9859f888326b6b605ea7fed1c0e