### PR TITLE
docs: update BSO command instructions for slash commands

### DIFF
--- a/docs/src/content/docs/bso/Miscellaneous/Events.md
+++ b/docs/src/content/docs/bso/Miscellaneous/Events.md
@@ -68,14 +68,14 @@ Note: The spooky gear and Eek are currently not able to be equipped and as such 
 
 ### Boosts
 
-You need only 4 scary items equipped for the max boost of 10 rolls. Be sure to equip a [Zak ](../custom-items/pets.md#miscellaneous-pets)if you have one to trick or treat for the max time possible. The easiest spooky items to find if you are unable to buy any items or are an iron is the skeleton set, which can be earned from killing skeletons with `=k skeleton`
+You need only 4 scary items equipped for the max boost of 10 rolls. Be sure to equip a [Zak ](../custom-items/pets.md#miscellaneous-pets)if you have one to trick or treat for the max time possible. The easiest spooky items to find if you are unable to buy any items or are an iron is the skeleton set, which can be earned from killing skeletons with [[/k name\:skeleton]]
 
 - Malygos/Ignecarus mask - 10% extra rolls
 - Warlock/Witch outfit (cloak, legs, top) - 10% extra rolls
 
 ### Trick or Treating
 
-The event can be started by using the command `=trickortreat or =tot` This command can only be run from 6pm - 4am (UK time) or from 1pm - 11pm (EST). You are also limited in the number of trips you can send per day to two, this was recently changed (10/15/21), along with an increase of rolls to 2.5x greater to allow you to still get the same output while sending less trips.
+The event can be started by using [[/trickortreat]] or [[/tot]]. This command can only be run from 6pm - 4am (UK time) or from 1pm - 11pm (EST). You are also limited in the number of trips you can send per day to two, this was recently changed (10/15/21), along with an increase of rolls to 2.5x greater to allow you to still get the same output while sending less trips.
 
 It gives various Halloween themed candies and foods as a result, including: Choc'rock, Chocolified skull, Eyescream, Rotten Sweets, Toffeet, Candy Teeth, Hairyfloss, Goblinfinger Soup, Benny's Brain Brew, and Roasted Newt. (In order below)
 
@@ -138,9 +138,9 @@ Unlike the Crack the Clue that rewarded a clue hunter set, this clue only gives 
 ### Activities
 
 The activities for the Christmas event are the following commands:\
-`=Xmas` - Used to assign your minion to a specific team, although it has no impact on the event, and you can participate in either trip.\
-`=Xmas Steal` - Sends your minion on a trip to **steal** presents\
-`=Xmas Deliver` - Sends your minion on a trip to **deliver** presents
+[[/xmas]] - Used to assign your minion to a specific team, although it has no impact on the event, and you can participate in either trip.\
+[[/xmas steal]] - Sends your minion on a trip to **steal** presents\
+[[/xmas deliver]] - Sends your minion on a trip to **deliver** presents
 
 ### Unique Items
 

--- a/docs/src/content/docs/getting-started/BSO.mdx
+++ b/docs/src/content/docs/getting-started/BSO.mdx
@@ -41,7 +41,7 @@ Some items are unique to BSO due to custom bosses, mechanic changes, and drop ta
 - Abyssal Equipment: Abyssal items are BSO-exclusive boost items which are dropped or have component drops from Malygos. The **Abyssal Cape** provides a 50% food consumption reduction against any bosses which require food. **Abyssal Dragon Bones** provide 5x more xp than Superior Dragon Bones, the next best prayer method. The **Abyssal Pouch** is created using a Giant Pouch and **Abyssal Thread**, and it provides a significant boost to your runecrafting speed.
 
 - XP Lamps:
-  Dailies can provide you with XP **lamps** (tiny, small, average, large, and huge) which can be placed in most skills after a short time has passed from the point of their release. These provide 20k, 50k, 100k, 1m, and 5m xp respectively. They are very rare and are used by `=lamp size lamp, skill`.
+  Dailies can provide you with XP **lamps** (tiny, small, average, large, and huge) which can be placed in most skills after a short time has passed from the point of their release. These provide 20k, 50k, 100k, 1m, and 5m xp respectively. They are very rare and are used via [[/minion lamp item\:<lamp name> skill\:<skill name>]] (select the lamp and skill you want from the slash command options).
 
 - Clues:
   Clues are stackable, _and_ there is a new tier of clue, **Grandmaster**. Grandmaster clues require you to complete 50 Master clue scrolls before you can attempt them. They have a unique drop table including some BSO exclusive items such as the **Clue Hunter Outfit** which halves time to complete clue scrolls, and the **Dwarven Blessing** which provides a 20% speed boost to all PvM activities at a cost of 1x Prayer Potion (4) per 5 minutes of the trip.
@@ -108,7 +108,7 @@ These BSO-exclusive pets provide some unqiue and powerful perks and are rare dro
 
 These BSO-exclusive master skillcapes provide varying perks to each skill, along with a global XP boost: +8% XP when training the corresponding skill and +3% XP to all other skills. This boost is always active while the cape is equipped in any gear tab.
 
-They can be purchased when you have 500m XP in a skill and cost 1b GP. The command to purchase one is `=skillcape hunter master cape` for example. These capes are untradeable.
+They can be purchased when you have 500m XP in a skill and cost 1b GP. The command to purchase one is [[/buy name\:Hunter master cape]] for example. These capes are untradeable.
 Skills with missing perks are either yet to be added or still unknown.
 
 - **Attack**: 15% speed boost to all non-boss PvM trips while training melee


### PR DESCRIPTION
## Summary
- replace the remaining legacy `=` command examples in the BSO getting started guide with their slash-command equivalents
- update the Halloween and Christmas event docs to reference the current slash commands for trick-or-treating, skeleton kills, and event tasks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ab4bb0e88326b5eb3d9cff88de8a