### PR TITLE
Update farming activity tests for new farming helper location

### DIFF
--- a/tests/unit/farmingActivity.test.ts
+++ b/tests/unit/farmingActivity.test.ts
@@ -9,6 +9,7 @@ const updateBankSettingMock = vi.fn();
 const addSubTaskMock = vi.fn();
 const sendToChannelMock = vi.fn();
 const userStatsBankUpdateMock = vi.fn();
+const calcVariableYieldMock = vi.fn().mockReturnValue(0);
 
 const redwoodPlant = {
 	id: 1,
@@ -44,8 +45,9 @@ const redwoodPlant = {
 } as const;
 
 vi.mock('@/lib/skilling/skills/farming/index.js', () => ({
-	default: {
-		Plants: [redwoodPlant]
+	Farming: {
+		Plants: [redwoodPlant],
+		calcVariableYield: calcVariableYieldMock
 	}
 }));
 
@@ -120,8 +122,8 @@ vi.mock('../../src/lib/util.ts', () => ({
 	skillingPetDropRate: vi.fn().mockReturnValue({ petDropRate: Number.POSITIVE_INFINITY })
 }));
 
-vi.mock('@/lib/skilling/functions/calcsFarming.js', () => ({
-	calcVariableYield: vi.fn().mockReturnValue(0)
+vi.mock('@/lib/skilling/skills/farming/utils/calcsFarming.js', () => ({
+	calcVariableYield: calcVariableYieldMock
 }));
 
 vi.mock('@/lib/canvas/chatHeadImage.js', () => ({


### PR DESCRIPTION
## Summary
- add a reusable calcVariableYield mock for the farming tests
- update the farming module mock to expose the new Farming export and helper
- retarget the calcVariableYield mock to the utils path used by the task

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68da2c2a61b48326b00df39763a949c9