### PR TITLE
Allow auto farm chaining to bypass busy checks

### DIFF
--- a/src/lib/util/addSubTaskToActivityTask.ts
+++ b/src/lib/util/addSubTaskToActivityTask.ts
@@ -5,10 +5,11 @@ import { logError } from '@/lib/util/logError.js';
 import { isGroupActivity } from '@/lib/util.js';
 
 export default async function addSubTaskToActivityTask<T extends ActivityTaskData>(
-	taskToAdd: Omit<T, 'finishDate' | 'id'>
+	taskToAdd: Omit<T, 'finishDate' | 'id'>,
+	finishingTaskID?: number
 ) {
 	const usersTask = ActivityManager.getActivityOfUser(taskToAdd.userID);
-	if (usersTask) {
+	if (usersTask && (!finishingTaskID || usersTask.id !== finishingTaskID)) {
 		throw new UserError(
 			`That user is busy, so they can't do this minion activity. They have a ${usersTask.type} activity still ongoing`
 		);

--- a/src/tasks/minions/farmingActivity.ts
+++ b/src/tasks/minions/farmingActivity.ts
@@ -187,24 +187,27 @@ export const farmingTask: MinionTask = {
 						nextPid = inserted.id;
 					}
 				}
-				await addSubTaskToActivityTask<FarmingActivityTaskOptions>({
-					plantsName: nextStep.plantsName,
-					patchType: nextStep.patchType,
-					userID,
-					channelID,
-					quantity: nextStep.quantity,
-					upgradeType: nextStep.upgradeType,
-					payment: nextStep.payment,
-					treeChopFeePaid: nextStep.treeChopFeePaid,
-					treeChopFeePlanned: nextStep.treeChopFeePlanned,
-					planting: nextStep.planting,
-					duration: nextStep.duration,
-					currentDate: nextStep.currentDate,
-					type: 'Farming',
-					autoFarmed: true,
-					pid: nextPid,
-					autoFarmPlan: remainingSteps
-				});
+				await addSubTaskToActivityTask<FarmingActivityTaskOptions>(
+					{
+						plantsName: nextStep.plantsName,
+						patchType: nextStep.patchType,
+						userID,
+						channelID,
+						quantity: nextStep.quantity,
+						upgradeType: nextStep.upgradeType,
+						payment: nextStep.payment,
+						treeChopFeePaid: nextStep.treeChopFeePaid,
+						treeChopFeePlanned: nextStep.treeChopFeePlanned,
+						planting: nextStep.planting,
+						duration: nextStep.duration,
+						currentDate: nextStep.currentDate,
+						type: 'Farming',
+						autoFarmed: true,
+						pid: nextPid,
+						autoFarmPlan: remainingSteps
+					},
+					data.id
+				);
 			}
 		} else if (patchType.patchPlanted) {
 			// If they do have something planted here, harvest it and possibly replant.
@@ -567,24 +570,27 @@ export const farmingTask: MinionTask = {
 						nextPid = inserted.id;
 					}
 				}
-				await addSubTaskToActivityTask<FarmingActivityTaskOptions>({
-					plantsName: nextStep.plantsName,
-					patchType: nextStep.patchType,
-					userID,
-					channelID,
-					quantity: nextStep.quantity,
-					upgradeType: nextStep.upgradeType,
-					payment: nextStep.payment,
-					treeChopFeePaid: nextStep.treeChopFeePaid,
-					treeChopFeePlanned: nextStep.treeChopFeePlanned,
-					planting: nextStep.planting,
-					duration: nextStep.duration,
-					currentDate: nextStep.currentDate,
-					type: 'Farming',
-					autoFarmed: true,
-					pid: nextPid,
-					autoFarmPlan: remainingSteps
-				});
+				await addSubTaskToActivityTask<FarmingActivityTaskOptions>(
+					{
+						plantsName: nextStep.plantsName,
+						patchType: nextStep.patchType,
+						userID,
+						channelID,
+						quantity: nextStep.quantity,
+						upgradeType: nextStep.upgradeType,
+						payment: nextStep.payment,
+						treeChopFeePaid: nextStep.treeChopFeePaid,
+						treeChopFeePlanned: nextStep.treeChopFeePlanned,
+						planting: nextStep.planting,
+						duration: nextStep.duration,
+						currentDate: nextStep.currentDate,
+						type: 'Farming',
+						autoFarmed: true,
+						pid: nextPid,
+						autoFarmPlan: remainingSteps
+					},
+					data.id
+				);
 			}
 		}
 	}

--- a/tests/unit/farmingAutofarmChaining.test.ts
+++ b/tests/unit/farmingAutofarmChaining.test.ts
@@ -44,9 +44,7 @@ const stubPlants = [stubPlant];
 
 vi.mock('@/lib/skilling/skills/farming/index.js', () => ({
 	Farming: {
-		Plants: {
-			find: (predicate: (plant: (typeof stubPlants)[number]) => boolean) => stubPlants.find(predicate)
-		},
+		Plants: stubPlants,
 		calcVariableYield: vi.fn().mockReturnValue(0)
 	}
 }));
@@ -188,10 +186,8 @@ describe('auto farm chaining busy check', () => {
 		const { farmingTask } = await import('../../src/tasks/minions/farmingActivity.js');
 		const { Farming } = await import('../../src/lib/skilling/skills/farming/index.js');
 
-		expect(
-			Farming.Plants.find(plant => plant.name === 'Test plant'),
-			'stub plant should be available for farming task'
-		).toBe(stubPlant);
+		const foundPlant = Farming.Plants.find(plant => plant.name === 'Test plant');
+		expect(foundPlant, 'stub plant should be available for farming task').toBe(stubPlant);
 
 		const nextStep: AutoFarmStepData = {
 			plantsName: 'Test plant',

--- a/tests/unit/farmingAutofarmChaining.test.ts
+++ b/tests/unit/farmingAutofarmChaining.test.ts
@@ -58,7 +58,7 @@ describe('auto farm chaining busy check', () => {
 		(globalThis as any).ActivityManager = originalActivityManager;
 		(globalThis as any).prisma = originalPrisma;
 		(globalThis as any).mUserFetch = originalMUserFetch;
-		vi.restoreAllMocks();
+		vi.clearAllMocks();
 	});
 
 	it('schedules the next step when the finishing activity is the only busy task', async () => {
@@ -94,7 +94,11 @@ describe('auto farm chaining busy check', () => {
 
 		(globalThis as any).prisma = {
 			activity: { create: createActivity },
-			farmedCrop: { create: createFarmedCrop }
+			farmedCrop: { create: createFarmedCrop },
+			clientStorage: {
+				findFirst: vi.fn().mockResolvedValue(null),
+				update: vi.fn().mockResolvedValue(undefined)
+			}
 		};
 
 		const getActivityOfUser = vi.fn().mockReturnValue({

--- a/tests/unit/farmingAutofarmChaining.test.ts
+++ b/tests/unit/farmingAutofarmChaining.test.ts
@@ -83,14 +83,10 @@ vi.mock('@/lib/util/logError.js', () => ({
 	}
 }));
 
-vi.mock(
-	'@oldschoolgg/rng',
-	() => ({
-		randInt: vi.fn().mockReturnValue(0),
-		roll: vi.fn().mockReturnValue(false)
-	}),
-	{ virtual: true }
-);
+vi.mock('@oldschoolgg/rng', () => ({
+	randInt: vi.fn().mockReturnValue(0),
+	roll: vi.fn().mockReturnValue(false)
+}));
 
 describe('auto farm chaining busy check', () => {
 	afterEach(() => {
@@ -230,7 +226,10 @@ describe('auto farm chaining busy check', () => {
 			autoFarmPlan: [nextStep]
 		};
 
-		await expect(farmingTask.run(data)).resolves.toBeUndefined();
+		const runPromise =
+			'isNew' in farmingTask ? farmingTask.run(data, { user, handleTripFinish }) : farmingTask.run(data);
+
+		await expect(runPromise).resolves.toBeUndefined();
 
 		expect(createActivity).toHaveBeenCalledOnce();
 		expect(getActivityOfUser).toHaveBeenCalledOnce();

--- a/tests/unit/farmingAutofarmChaining.test.ts
+++ b/tests/unit/farmingAutofarmChaining.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AutoFarmStepData, FarmingActivityTaskOptions } from '../../src/lib/types/minions.js';
+
+const handleTripFinish = vi.fn();
+const updateBankSetting = vi.fn();
+const userStatsBankUpdate = vi.fn();
+
+const stubPlant = {
+	id: 1,
+	name: 'Test plant',
+	aliases: ['test plant'],
+	seedType: 'test',
+	plantXp: 10,
+	checkXp: 0,
+	harvestXp: 0,
+	herbXp: undefined,
+	herbLvl: undefined,
+	inputItems: {},
+	outputLogs: undefined,
+	outputRoots: undefined,
+	givesLogs: false,
+	givesCrops: false,
+	fixedOutput: false,
+	variableYield: false,
+	numOfStages: 1,
+	chanceOfDeath: 0,
+	chance1: 0,
+	chance99: 0,
+	treeWoodcuttingLevel: undefined,
+	needsChopForHarvest: false,
+	petChance: 0,
+	growthTime: 0,
+	timePerPatchTravel: 0,
+	timePerHarvest: 0,
+	woodcuttingXp: 0,
+	canPayFarmer: false,
+	canCompostPatch: false,
+	canCompostandPay: false
+} as const;
+
+vi.mock('@/lib/skilling/skills/farming/index.js', () => ({
+	Farming: {
+		Plants: [stubPlant],
+		calcVariableYield: vi.fn()
+	}
+}));
+
+vi.mock('@/lib/skilling/skills/farming/utils/farmingHelpers.js', () => ({
+	getFarmingKeyFromName: vi.fn().mockReturnValue('test_patch')
+}));
+
+vi.mock('@/lib/util/handleTripFinish.js', () => ({
+	handleTripFinish
+}));
+
+vi.mock('@/lib/util/updateBankSetting.js', () => ({
+	updateBankSetting
+}));
+
+vi.mock('@/mahoji/mahojiSettings.js', () => ({
+	userStatsBankUpdate
+}));
+
+vi.mock('@/lib/util.js', () => ({
+	skillingPetDropRate: vi.fn().mockReturnValue({ petDropRate: Number.POSITIVE_INFINITY })
+}));
+
+vi.mock('@/lib/canvas/chatHeadImage.js', () => ({
+	default: vi.fn()
+}));
+
+vi.mock('@/lib/combat_achievements/combatAchievements.js', () => ({
+	combatAchievementTripEffect: vi.fn()
+}));
+
+vi.mock('@/lib/util/logError.js', () => ({
+	logError: vi.fn(),
+	assert: (condition: unknown, message?: string) => {
+		if (!condition) {
+			throw new Error(message ?? 'Assertion failed');
+		}
+	}
+}));
+
+vi.mock(
+	'@oldschoolgg/rng',
+	() => ({
+		randInt: vi.fn().mockReturnValue(0),
+		roll: vi.fn().mockReturnValue(false)
+	}),
+	{ virtual: true }
+);
+
+describe('auto farm chaining busy check', () => {
+	afterEach(() => {
+		delete (globalThis as any).ActivityManager;
+		delete (globalThis as any).prisma;
+		delete (globalThis as any).mUserFetch;
+	});
+
+	it('schedules the next step when the finishing activity is the only busy task', async () => {
+		const userID = '123';
+		const channelID = '789';
+		const finishingTaskID = 456;
+		const now = Date.now();
+
+		const createdActivity = {
+			id: 999,
+			user_id: BigInt(userID),
+			channel_id: BigInt(channelID),
+			finish_date: new Date(now + 1000),
+			start_date: new Date(now),
+			completed: false,
+			type: 'Farming',
+			data: {},
+			group_activity: false,
+			duration: 1000
+		};
+
+		const createActivity = vi.fn().mockImplementation(async ({ data }: { data: any }) => ({
+			...createdActivity,
+			finish_date: data.finish_date,
+			start_date: data.start_date,
+			user_id: data.user_id,
+			channel_id: data.channel_id,
+			data: data.data,
+			duration: data.duration
+		}));
+
+		const createFarmedCrop = vi.fn().mockResolvedValue({ id: 321 });
+
+		(globalThis as any).prisma = {
+			activity: { create: createActivity },
+			farmedCrop: { create: createFarmedCrop }
+		};
+
+		const getActivityOfUser = vi.fn().mockReturnValue({
+			id: finishingTaskID,
+			type: 'Farming'
+		});
+		const activitySync = vi.fn();
+
+		(globalThis as any).ActivityManager = {
+			getActivityOfUser,
+			activitySync
+		};
+
+		const user = {
+			id: userID,
+			user: { completed_ca_task_ids: [] },
+			toString: () => 'TestUser',
+			minionName: 'Test Minion',
+			skillsAsLevels: { farming: 99, woodcutting: 99 },
+			skillsAsXP: { farming: 13_000_000, woodcutting: 13_000_000 },
+			bitfield: [] as number[],
+			hasEquippedOrInBank: vi.fn().mockReturnValue(false),
+			hasEquipped: vi.fn().mockReturnValue(false),
+			gear: {
+				melee: { hasEquipped: vi.fn().mockReturnValue(false) },
+				range: { hasEquipped: vi.fn().mockReturnValue(false) },
+				mage: { hasEquipped: vi.fn().mockReturnValue(false) }
+			},
+			bank: { clone: () => ({}) },
+			cl: { clone: () => ({}) },
+			addXP: vi.fn().mockResolvedValue('xp gained'),
+			addItemsToCollectionLog: vi.fn().mockResolvedValue(undefined),
+			transactItems: vi.fn().mockResolvedValue(undefined),
+			update: vi.fn().mockResolvedValue(undefined),
+			farmingContract: vi.fn().mockReturnValue({
+				contract: {
+					plantsContract: null,
+					seedType: null,
+					quantity: 0,
+					contractsCompleted: 0
+				}
+			})
+		};
+
+		(globalThis as any).mUserFetch = vi.fn().mockResolvedValue(user);
+
+		const { farmingTask } = await import('../../src/tasks/minions/farmingActivity.js');
+
+		const nextStep: AutoFarmStepData = {
+			plantsName: 'Test plant',
+			quantity: 1,
+			upgradeType: null,
+			payment: false,
+			treeChopFeePaid: 0,
+			treeChopFeePlanned: 0,
+			patchType: {
+				lastPlanted: null,
+				patchPlanted: false,
+				plantTime: now,
+				lastQuantity: 0,
+				lastUpgradeType: null,
+				lastPayment: false,
+				pid: undefined
+			},
+			planting: true,
+			currentDate: now,
+			duration: 1000
+		};
+
+		const data: FarmingActivityTaskOptions = {
+			type: 'Farming',
+			id: finishingTaskID,
+			finishDate: now,
+			userID,
+			channelID,
+			duration: 1000,
+			plantsName: 'Test plant',
+			quantity: 1,
+			upgradeType: null,
+			payment: false,
+			treeChopFeePaid: 0,
+			treeChopFeePlanned: 0,
+			patchType: {
+				lastPlanted: null,
+				patchPlanted: false,
+				plantTime: now,
+				lastQuantity: 0,
+				lastUpgradeType: null,
+				lastPayment: false,
+				pid: undefined
+			},
+			planting: true,
+			currentDate: now,
+			autoFarmed: true,
+			autoFarmPlan: [nextStep]
+		};
+
+		await expect(farmingTask.run(data)).resolves.toBeUndefined();
+
+		expect(createActivity).toHaveBeenCalledOnce();
+		expect(getActivityOfUser).toHaveBeenCalledOnce();
+		expect(activitySync).toHaveBeenCalledOnce();
+	});
+});

--- a/tests/unit/farmingAutofarmChaining.test.ts
+++ b/tests/unit/farmingAutofarmChaining.test.ts
@@ -6,6 +6,10 @@ import type { AutoFarmStepData, FarmingActivityTaskOptions } from '../../src/lib
 const handleTripFinish = vi.fn();
 const updateBankSetting = vi.fn();
 const userStatsBankUpdate = vi.fn();
+const mahojiClientSettingsFetch = vi.fn().mockResolvedValue({
+	farming_loot_bank: {}
+});
+const mahojiClientSettingsUpdate = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@/lib/skilling/skills/farming/utils/farmingHelpers.js', () => ({
 	getFarmingKeyFromName: vi.fn().mockReturnValue('test_patch')
@@ -17,6 +21,11 @@ vi.mock('@/lib/util/handleTripFinish.js', () => ({
 
 vi.mock('@/lib/util/updateBankSetting.js', () => ({
 	updateBankSetting
+}));
+
+vi.mock('@/lib/util/clientSettings.js', () => ({
+	mahojiClientSettingsFetch,
+	mahojiClientSettingsUpdate
 }));
 
 vi.mock('@/mahoji/mahojiSettings.js', () => ({
@@ -133,6 +142,7 @@ describe('auto farm chaining busy check', () => {
 			addItemsToCollectionLog: vi.fn().mockResolvedValue(undefined),
 			transactItems: vi.fn().mockResolvedValue(undefined),
 			update: vi.fn().mockResolvedValue(undefined),
+			perkTier: vi.fn().mockReturnValue(0),
 			farmingContract: vi.fn().mockReturnValue({
 				contract: {
 					plantsContract: null,

--- a/tests/unit/farmingAutofarmChaining.test.ts
+++ b/tests/unit/farmingAutofarmChaining.test.ts
@@ -7,48 +7,6 @@ const handleTripFinish = vi.fn();
 const updateBankSetting = vi.fn();
 const userStatsBankUpdate = vi.fn();
 
-const stubPlant = {
-	id: 1,
-	name: 'Test plant',
-	aliases: ['test plant'],
-	seedType: 'test',
-	plantXp: 10,
-	checkXp: 0,
-	harvestXp: 0,
-	herbXp: undefined,
-	herbLvl: undefined,
-	inputItems: {},
-	outputLogs: undefined,
-	outputRoots: undefined,
-	givesLogs: false,
-	givesCrops: false,
-	fixedOutput: false,
-	variableYield: false,
-	numOfStages: 1,
-	chanceOfDeath: 0,
-	chance1: 0,
-	chance99: 0,
-	treeWoodcuttingLevel: undefined,
-	needsChopForHarvest: false,
-	petChance: 0,
-	growthTime: 0,
-	timePerPatchTravel: 0,
-	timePerHarvest: 0,
-	woodcuttingXp: 0,
-	canPayFarmer: false,
-	canCompostPatch: false,
-	canCompostandPay: false
-} as const;
-
-const stubPlants = [stubPlant];
-
-vi.mock('@/lib/skilling/skills/farming/index.js', () => ({
-	Farming: {
-		Plants: stubPlants,
-		calcVariableYield: vi.fn().mockReturnValue(0)
-	}
-}));
-
 vi.mock('@/lib/skilling/skills/farming/utils/farmingHelpers.js', () => ({
 	getFarmingKeyFromName: vi.fn().mockReturnValue('test_patch')
 }));
@@ -186,11 +144,12 @@ describe('auto farm chaining busy check', () => {
 		const { farmingTask } = await import('../../src/tasks/minions/farmingActivity.js');
 		const { Farming } = await import('../../src/lib/skilling/skills/farming/index.js');
 
-		const foundPlant = Farming.Plants.find(plant => plant.name === 'Test plant');
-		expect(foundPlant, 'stub plant should be available for farming task').toBe(stubPlant);
+		const plant = Farming.Plants.find(p => p.name === 'Guam');
+		expect(plant, 'guam plant should exist in farming data').not.toBeNull();
+		const plantName = plant!.name;
 
 		const nextStep: AutoFarmStepData = {
-			plantsName: 'Test plant',
+			plantsName: plantName,
 			quantity: 1,
 			upgradeType: null,
 			payment: false,
@@ -217,7 +176,7 @@ describe('auto farm chaining busy check', () => {
 			userID,
 			channelID,
 			duration: 1000,
-			plantsName: 'Test plant',
+			plantsName: plantName,
 			quantity: 1,
 			upgradeType: null,
 			payment: false,

--- a/tests/unit/farmingAutofarmChaining.test.ts
+++ b/tests/unit/farmingAutofarmChaining.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { MUser } from '../../src/lib/MUser.js';
 import type { AutoFarmStepData, FarmingActivityTaskOptions } from '../../src/lib/types/minions.js';
 
 const handleTripFinish = vi.fn();
@@ -171,7 +172,7 @@ describe('auto farm chaining busy check', () => {
 					contractsCompleted: 0
 				}
 			})
-		};
+		} as unknown as MUser;
 
 		(globalThis as any).mUserFetch = vi.fn().mockResolvedValue(user);
 


### PR DESCRIPTION
## Summary
- allow `addSubTaskToActivityTask` to accept the finishing task id so it can skip the busy guard for the completing activity
- pass the current farming activity id when chaining auto-farm steps so follow-up tasks are not blocked
- add a unit test that runs a chained auto-farm scenario to ensure the busy check no longer rejects it

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68da71951ed0832695c9186ca713cf53