### PR TITLE
Refactor compost label formatting

### DIFF
--- a/src/lib/minions/functions/autoFarm.ts
+++ b/src/lib/minions/functions/autoFarm.ts
@@ -33,15 +33,14 @@ interface BuildSummaryResult {
 	extraInfoLines: string[];
 }
 
+const compostLabels: Record<CropUpgradeType, string> = {
+	compost: 'Compost',
+	supercompost: 'Supercompost',
+	ultracompost: 'Ultracompost'
+};
+
 function formatCompostLabel(upgradeType: CropUpgradeType, quantity: number): string {
-	const label =
-		upgradeType === 'compost'
-			? 'Compost'
-			: upgradeType === 'supercompost'
-				? 'Supercompost'
-				: upgradeType === 'ultracompost'
-					? 'Ultracompost'
-					: upgradeType;
+	const label = compostLabels[upgradeType] ?? upgradeType;
 	return `${quantity.toLocaleString()}x ${label}`;
 }
 


### PR DESCRIPTION
## Summary
- replace the nested ternary in `formatCompostLabel` with a lookup map for readability

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68db88bce7608326846b4da8511f61c9