### PR TITLE
Fix farming loot regressions and auto farm button logic

### DIFF
--- a/docs/src/content/docs/osb/Skills/farming/README.md
+++ b/docs/src/content/docs/osb/Skills/farming/README.md
@@ -107,7 +107,7 @@ Patch counts depend on your quest points, Farming level, and quest progression. 
 | Flower | 4 | +1 once you unlock Canifis or Prifddinas flower patches, +1 @ 45 Farming (Farming Guild), +1 after *Children of the Sun* |
 | Hardwood | 0 | +3 @ 3 QP (Fossil Island), +1 after *Children of the Sun* |
 | Vine | 12 | Always available in the Hosidius vinery |
-| Bush | 3 | +1 @ 3 QP (Etceteria), +1 @ 45 Farming (Farming Guild low), +1 after *Children of the Sun* |
+| Bush | 3 | +1 @ 3 QP (Etceteria), +1 @ 45 Farming (Farming Guild low) |
 | Hops | 4 | No additional unlocks |
 | Mushroom | 0 | +1 @ 1 QP (Canifis) |
 | Belladonna | 1 | +1 after *Children of the Sun* |

--- a/tests/unit/combinedAutoFarmActivity.test.ts
+++ b/tests/unit/combinedAutoFarmActivity.test.ts
@@ -1,0 +1,137 @@
+import { Bank } from 'oldschooljs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BitField } from '../../src/lib/constants.js';
+import type { FarmingActivityTaskOptions } from '../../src/lib/types/minions.js';
+
+const executeFarmingStepMock = vi.fn();
+const handleTripFinishMock = vi.fn();
+const makeAutoContractButtonMock = vi.fn().mockReturnValue('AUTO_BUTTON');
+const canRunAutoContractMock = vi.fn();
+
+vi.mock('../../src/tasks/minions/farmingStep.js', () => ({
+	executeFarmingStep: executeFarmingStepMock
+}));
+vi.mock('../../src/lib/util/handleTripFinish.js', () => ({
+	handleTripFinish: handleTripFinishMock
+}));
+vi.mock('../../src/lib/util/interactions.js', () => ({
+	makeAutoContractButton: makeAutoContractButtonMock
+}));
+vi.mock('../../src/mahoji/lib/abstracted_commands/farmingContractCommand.js', () => ({
+	canRunAutoContract: canRunAutoContractMock
+}));
+
+const { handleCombinedAutoFarm } = await import('../../src/tasks/minions/combinedAutoFarmActivity.js');
+
+describe('handleCombinedAutoFarm auto contract button behaviour', () => {
+	let user: MUserStub;
+	let taskData: FarmingActivityTaskOptions;
+
+	beforeEach(() => {
+		executeFarmingStepMock.mockReset();
+		handleTripFinishMock.mockReset();
+		makeAutoContractButtonMock.mockReset().mockReturnValue('AUTO_BUTTON');
+		canRunAutoContractMock.mockReset();
+
+		executeFarmingStepMock.mockResolvedValue({
+			message: 'finished step',
+			loot: new Bank().add('Seed pack', 1),
+			summary: {
+				duration: 60_000,
+				xp: {
+					planting: 0,
+					harvest: 0,
+					checkHealth: 0,
+					rake: 0,
+					bonus: 0,
+					totalFarming: 0,
+					woodcutting: 0,
+					herblore: 0
+				},
+				xpMessages: {},
+				contractCompleted: true
+			}
+		});
+
+		user = {
+			id: '1',
+			bitfield: [] as number[],
+			minionName: 'AutoFarmer',
+			toString() {
+				return 'AutoFarmer';
+			}
+		};
+
+		taskData = {
+			type: 'Farming',
+			plantsName: 'Test herb',
+			patchType: {} as any,
+			userID: '1',
+			channelID: '123',
+			quantity: 1,
+			upgradeType: null,
+			payment: false,
+			treeChopFeePaid: 0,
+			treeChopFeePlanned: 0,
+			planting: true,
+			duration: 60_000,
+			currentDate: Date.now(),
+			finishDate: Date.now() + 60_000,
+			autoFarmed: true,
+			autoFarmPlan: [
+				{
+					plantsName: 'Test herb',
+					quantity: 1,
+					upgradeType: null,
+					payment: false,
+					treeChopFeePaid: 0,
+					treeChopFeePlanned: 0,
+					patchType: {} as any,
+					planting: true,
+					currentDate: Date.now(),
+					duration: 60_000
+				}
+			]
+		} as FarmingActivityTaskOptions;
+	});
+
+	it('relies on handleTripFinish when auto contract is available', async () => {
+		canRunAutoContractMock.mockResolvedValue(true);
+
+		await handleCombinedAutoFarm({ user: user as any, taskData });
+
+		expect(handleTripFinishMock).toHaveBeenCalledTimes(1);
+		const extraComponents = handleTripFinishMock.mock.calls[0]?.[7];
+		expect(extraComponents).toBeUndefined();
+		expect(makeAutoContractButtonMock).not.toHaveBeenCalled();
+	});
+
+	it('adds auto contract button when contract completed but auto contract unavailable', async () => {
+		canRunAutoContractMock.mockResolvedValue(false);
+
+		await handleCombinedAutoFarm({ user: user as any, taskData });
+
+		const extraComponents = handleTripFinishMock.mock.calls[0]?.[7];
+		expect(extraComponents).toEqual(['AUTO_BUTTON']);
+		expect(makeAutoContractButtonMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('respects the disable auto contract button bitfield', async () => {
+		canRunAutoContractMock.mockResolvedValue(false);
+		user.bitfield = [BitField.DisableAutoFarmContractButton];
+
+		await handleCombinedAutoFarm({ user: user as any, taskData });
+
+		const extraComponents = handleTripFinishMock.mock.calls[0]?.[7];
+		expect(extraComponents).toBeUndefined();
+		expect(makeAutoContractButtonMock).not.toHaveBeenCalled();
+	});
+});
+
+type MUserStub = {
+	id: string;
+	bitfield: number[];
+	minionName: string;
+	toString(): string;
+};


### PR DESCRIPTION
## Summary
- restore farming woodcutting harvests to award roots again and surface rake XP in the trip summary
- ensure newly unlocked patches grant the correct weeds and XP while updating docs to match the live bush patch count
- prevent duplicate auto contract buttons after combined auto farming and cover the fixes with unit tests

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68dd08c68c9c8326b26b69de5651c508