### PR TITLE
Add fallback-aware zero-time activity configuration

### DIFF
--- a/docs/src/content/docs/osb/Miscellaneous/zero-time-activities.md
+++ b/docs/src/content/docs/osb/Miscellaneous/zero-time-activities.md
@@ -6,13 +6,13 @@ Zero-time activities let your minion cast High Alchemy or fletch stackable ammun
 
 ## Configuring `/zero_time_activity`
 
-1. Choose your background action with [[/zero_time_activity type\:alch]] or [[/zero_time_activity type\:fletch]].
-2. If you select `fletch`, provide the exact item with [[/zero_time_activity type\:fletch item\:"Rune dart"]] (autocomplete suggests every supported choice).
-3. For `alch`, leave the item blank to let the bot automatically pick from your favourite alchs each trip, or specify a particular item such as [[/zero_time_activity type\:alch item\:"Yew longbow"]].
-4. Update your favourite alch list with [[/config user favorite_alchs add\:Rune platebody]] so automatic selection has options to choose from.
-5. Use [[/zero_time_activity clear\:true]] to remove the configuration.
+- Use [[/zero_time_activity]] (or [[/zero_time_activity overview]]) to see your saved preferences, readiness, and any blockers.
+- Configure your primary preference with [[/zero_time_activity set primary_type\:alch]] or [[/zero_time_activity set primary_type\:fletch primary_item\:"Rune dart"]]. Autocomplete now lists every valid fletchable alongside the required level and Slayer unlocks.
+- Add a fallback with [[/zero_time_activity set primary_type\:alch fallback_type\:fletch fallback_item\:"Rune dart"]] so trips automatically swap to the next viable option if the primary setup is unavailable.
+- Keep `Alch (automatic favourites)` stocked by adding favourite alchs via [[/config user favorite_alchs add\:Rune platebody]].
+- Remove everything with [[/zero_time_activity clear]].
 
-Only one zero-time activity can run per trip. Switching between alching and fletching requires re-running `/zero_time_activity`. The necessary runes or fletching materials are removed from your bank when the trip starts, and zero-time actions never extend the duration of the main activity.
+Only one zero-time action runs per trip, but the fallback preference means you rarely waste a lap. Supplies are withdrawn when the trip begins, and any automatic switch highlights the reason (for example, “Primary alch: You're missing resources… Falling back to Fletch Rune dart.”).
 
 ## Zero-time Alching
 

--- a/docs/src/content/docs/osb/Skills/agility.md
+++ b/docs/src/content/docs/osb/Skills/agility.md
@@ -27,8 +27,8 @@ For max efficiency spam quantity 1 trips when close to leveling up.
 
 Read the [Zero-time Activities guide](/osb/miscellaneous/zero-time-activities) for complete setup instructions before you start running laps.
 
-- [[/zero_time_activity set primary_type\:alch]] performs roughly 277 High Alchemy casts per hour while you train Agility. Leaving primary_item blank lets the bot choose from your favourite alchs at the start of every trip.
-- [[/zero_time_activity set primary_type\:fletch primary_item\:"Rune dart"]] converts stackable ammunition at up to ~15,000 items per hour during rooftop laps; add a fallback preference to keep fletching when alching isn't possible.
+- [[/zero_time_activity set primary_type\:alch]] performs roughly 277 High Alchemy casts per hour while you train Agility. Leaving `primary_item` blank lets the bot choose from your favourite alchs at the start of every trip.
+- Pair that with [[/zero_time_activity set primary_type\:alch fallback_type\:fletch fallback_item\:"Rune dart"]] so laps automatically fall back to fletching when supplies or course rules block alching—the trip result will call out the reason for the swap.
 
 Once configured, simply send [[/laps]] commands—zero-time actions happen automatically alongside your runs. Remember that the Ape Atoll course blocks alching because of the greegree requirement, although zero-time fletching still works there.
 

--- a/docs/src/content/docs/osb/Skills/fletching.md
+++ b/docs/src/content/docs/osb/Skills/fletching.md
@@ -17,8 +17,8 @@ You can train Fletching with the [[/fletch]] command. To see all the items you c
 
 ### Zero-time Fletching
 
-Configure zero-time fletching with [[/zero_time_activity]], then run Agility laps or the Hallowed Sepulchre to craft ammunition in the background. The [Zero-time Activities guide](/osb/miscellaneous/zero-time-activities) lists every supported item, setup step, and hourly rate.
+Configure zero-time fletching with [[/zero_time_activity set primary_type\:fletch primary_item\:"Rune dart"]], then run Agility laps or the Hallowed Sepulchre to craft ammunition in the background. The [Zero-time Activities guide](/osb/miscellaneous/zero-time-activities) lists every supported item, setup step, and hourly rate.
 
-- Example setup: [[/zero_time_activity type\:fletch item\:"Rune dart"]]
-- Zero-time alching is configured the same way with `type:alch`, and leaving the item blank lets the bot choose from your favourite alchs at the start of each trip.
+- Add a fallback alch with [[/zero_time_activity set primary_type\:fletch primary_item\:"Rune dart" fallback_type\:alch]] so the bot keeps working even when you run out of supplies.
+- Leaving the `primary_item` blank on an alch setup keeps using your favourite alchs automatically.
 

--- a/src/lib/util/zeroTimeActivity.ts
+++ b/src/lib/util/zeroTimeActivity.ts
@@ -47,28 +47,84 @@ export type ZeroTimeActivityResult =
 	  };
 
 export interface ZeroTimeActivityResponse {
-	result: ZeroTimeActivityResult | null;
-	message?: string;
+        result: ZeroTimeActivityResult | null;
+        message?: string;
 }
 
 interface BaseAttemptZeroTimeActivityOptions {
-	user: MUser;
-	duration: number;
-	preference: ZeroTimeActivityPreference;
-	quantityOverride?: number;
-	itemsPerHour?: number;
+        user: MUser;
+        duration: number;
+        preference: ZeroTimeActivityPreference;
+        quantityOverride?: number;
+        itemsPerHour?: number;
 }
 
 export interface AttemptZeroTimeAlchOptions extends BaseAttemptZeroTimeActivityOptions {
-	preference: ZeroTimeActivityPreference & { type: 'alch' };
-	variant?: 'agility' | 'default';
+        preference: ZeroTimeActivityPreference & { type: 'alch' };
+        variant?: 'agility' | 'default';
 }
 
 export interface AttemptZeroTimeFletchOptions extends BaseAttemptZeroTimeActivityOptions {
-	preference: ZeroTimeActivityPreference & { type: 'fletch' };
+        preference: ZeroTimeActivityPreference & { type: 'fletch' };
 }
 
-export type AttemptZeroTimeActivityOptions = AttemptZeroTimeAlchOptions | AttemptZeroTimeFletchOptions;
+type ItemsPerHourResolver = number | ((preference: ZeroTimeActivityPreference) => number | undefined);
+
+interface AttemptZeroTimeContextBase {
+        disabledReason?: string;
+        itemsPerHour?: ItemsPerHourResolver;
+}
+
+export interface AttemptZeroTimeAlchContext extends AttemptZeroTimeContextBase {
+        variant?: 'agility' | 'default';
+}
+
+export type AttemptZeroTimeFletchContext = AttemptZeroTimeContextBase;
+
+export interface AttemptZeroTimeActivityOptions {
+        user: MUser;
+        duration: number;
+        preferences: ZeroTimePreferenceList;
+        quantityOverride?: number;
+        alch?: AttemptZeroTimeAlchContext;
+        fletch?: AttemptZeroTimeFletchContext;
+}
+
+export interface AttemptZeroTimeActivityFailure {
+        preference: ZeroTimeActivityPreference;
+        message?: string;
+}
+
+export interface AttemptZeroTimeActivityOutcome {
+        result: ZeroTimeActivityResult | null;
+        failures: AttemptZeroTimeActivityFailure[];
+}
+
+export function getZeroTimePreferenceLabel(preference: ZeroTimeActivityPreference): string {
+        const roleLabel = preference.role === 'primary' ? 'Primary' : 'Fallback';
+        const typeLabel = preference.type === 'alch' ? 'alch' : 'fletch';
+        return `${roleLabel} ${typeLabel}`;
+}
+
+export function describeZeroTimePreference(preference: ZeroTimeActivityPreference): string {
+        if (preference.type === 'alch') {
+                if (!preference.itemID) {
+                        return 'Alch (automatic favourites)';
+                }
+                const item = Items.get(preference.itemID);
+                const itemName = item?.name ?? 'unknown item';
+                return `Alch ${itemName}`;
+        }
+
+        const item = preference.itemID ? Items.get(preference.itemID) : null;
+        const itemName = item?.name ?? 'unspecified fletchable';
+        return `Fletch ${itemName}`;
+}
+
+export function formatZeroTimePreference(preference: ZeroTimeActivityPreference): string {
+        const roleLabel = preference.role === 'primary' ? 'Primary' : 'Fallback';
+        return `${roleLabel}: ${describeZeroTimePreference(preference)}`;
+}
 
 export function getZeroTimeActivityPreferences(user: MUser): ZeroTimePreferenceList {
 	const preferences: ZeroTimePreferenceList = [];
@@ -333,10 +389,75 @@ function calculateFletching(options: AttemptZeroTimeFletchOptions): ZeroTimeActi
 	};
 }
 
-export function attemptZeroTimeActivity(options: AttemptZeroTimeActivityOptions): ZeroTimeActivityResponse {
-	if (options.preference.type === 'alch') {
-		return calculateAlching(options);
-	}
+function attemptZeroTimePreference(
+        options: AttemptZeroTimeAlchOptions | AttemptZeroTimeFletchOptions
+): ZeroTimeActivityResponse {
+        if (options.preference.type === 'alch') {
+                return calculateAlching(options);
+        }
 
-	return calculateFletching(options);
+        return calculateFletching(options);
+}
+
+export function attemptZeroTimeActivity(options: AttemptZeroTimeActivityOptions): AttemptZeroTimeActivityOutcome {
+        const failures: AttemptZeroTimeActivityFailure[] = [];
+
+        const resolveItemsPerHour = (
+                resolver: ItemsPerHourResolver | undefined,
+                preference: ZeroTimeActivityPreference
+        ): number | undefined => {
+                if (typeof resolver === 'function') {
+                        return resolver(preference);
+                }
+                return resolver;
+        };
+
+        for (const preference of options.preferences) {
+                if (preference.type === 'alch') {
+                        if (options.alch?.disabledReason) {
+                                failures.push({ preference, message: options.alch.disabledReason });
+                                continue;
+                        }
+                        const attempt = attemptZeroTimePreference({
+                                user: options.user,
+                                duration: options.duration,
+                                preference: preference as ZeroTimeActivityPreference & { type: 'alch' },
+                                quantityOverride: options.quantityOverride,
+                                itemsPerHour: resolveItemsPerHour(options.alch?.itemsPerHour, preference),
+                                variant: options.alch?.variant
+                        });
+
+                        if (attempt.result) {
+                                return { result: attempt.result, failures };
+                        }
+
+                        if (attempt.message) {
+                                failures.push({ preference, message: attempt.message });
+                        }
+                        continue;
+                }
+
+                if (options.fletch?.disabledReason) {
+                        failures.push({ preference, message: options.fletch.disabledReason });
+                        continue;
+                }
+
+                const attempt = attemptZeroTimePreference({
+                        user: options.user,
+                        duration: options.duration,
+                        preference: preference as ZeroTimeActivityPreference & { type: 'fletch' },
+                        quantityOverride: options.quantityOverride,
+                        itemsPerHour: resolveItemsPerHour(options.fletch?.itemsPerHour, preference)
+                });
+
+                if (attempt.result) {
+                        return { result: attempt.result, failures };
+                }
+
+                if (attempt.message) {
+                        failures.push({ preference, message: attempt.message });
+                }
+        }
+
+        return { result: null, failures };
 }

--- a/src/mahoji/commands/laps.ts
+++ b/src/mahoji/commands/laps.ts
@@ -8,11 +8,11 @@ import addSubTaskToActivityTask from '@/lib/util/addSubTaskToActivityTask.js';
 import { calcMaxTripLength } from '@/lib/util/calcMaxTripLength.js';
 import { updateBankSetting } from '@/lib/util/updateBankSetting.js';
 import {
-	type AttemptZeroTimeActivityOptions,
-	attemptZeroTimeActivity,
-	getZeroTimeActivityPreferences,
-	type ZeroTimeActivityPreference,
-	type ZeroTimeActivityResult
+        attemptZeroTimeActivity,
+        describeZeroTimePreference,
+        getZeroTimeActivityPreferences,
+        getZeroTimePreferenceLabel,
+        type ZeroTimeActivityResult
 } from '@/lib/util/zeroTimeActivity.js';
 import { timePerAlchAgility } from '@/mahoji/lib/abstracted_commands/alchCommand.js';
 
@@ -105,74 +105,79 @@ export const lapsCommand: OSBMahojiCommand = {
 		let fletchResult: FletchResult | null = null;
 		let alchResult: AlchResult | null = null;
 		const infoMessages: string[] = [];
-		const preferences = getZeroTimeActivityPreferences(user);
+                const preferences = getZeroTimeActivityPreferences(user);
 
-		for (const preference of preferences) {
-			const label = preference.role === 'primary' ? 'Primary' : 'Fallback';
+                if (preferences.length > 0) {
+                        const alchDisabledReason =
+                                course.name === 'Ape Atoll Agility Course'
+                                        ? 'Alching is unavailable on this course because your minion must hold a greegree.'
+                                        : undefined;
 
-			if (preference.type === 'alch' && course.name === 'Ape Atoll Agility Course') {
-				infoMessages.push(`${label} alching is unavailable on this course.`);
-				continue;
-			}
+                        const outcome = attemptZeroTimeActivity({
+                                user,
+                                duration,
+                                preferences,
+                                alch: {
+                                        variant: 'agility',
+                                        itemsPerHour: AGILITY_ALCHES_PER_HOUR,
+                                        ...(alchDisabledReason ? { disabledReason: alchDisabledReason } : {})
+                                },
+                                fletch: { itemsPerHour: AGILITY_FLETCH_ITEMS_PER_HOUR }
+                        });
 
-			const attemptOptions: AttemptZeroTimeActivityOptions =
-				preference.type === 'alch'
-					? {
-						user,
-						duration,
-						preference: preference as ZeroTimeActivityPreference & { type: 'alch' },
-						variant: 'agility',
-						itemsPerHour: AGILITY_ALCHES_PER_HOUR
-					  }
-					: {
-						user,
-						duration,
-						preference: preference as ZeroTimeActivityPreference & { type: 'fletch' },
-						itemsPerHour: AGILITY_FLETCH_ITEMS_PER_HOUR
-					  };
+                        if (outcome.result?.type === 'fletch') {
+                                fletchResult = outcome.result;
+                        } else if (outcome.result?.type === 'alch') {
+                                alchResult = outcome.result;
+                        }
 
-			const attempt = attemptZeroTimeActivity(attemptOptions);
+                        const formattedFailures = outcome.failures
+                                .filter(failure => failure.message)
+                                .map(
+                                        failure =>
+                                                `${getZeroTimePreferenceLabel(failure.preference)}: ${failure.message}`
+                                );
 
-			if (attempt.result) {
-				if (attempt.result.type === 'fletch') {
-					fletchResult = attempt.result;
-				} else {
-					alchResult = attempt.result;
-				}
-				break;
-			}
-
-			if (attempt.message) {
-				infoMessages.push(`${label} ${preference.type}: ${attempt.message}`);
-			}
-		}
+                        if (outcome.result) {
+                                if (outcome.result.preference.role === 'fallback') {
+                                        const fallbackDescription = describeZeroTimePreference(
+                                                outcome.result.preference
+                                        );
+                                        const prefix = formattedFailures.length > 0 ? `${formattedFailures.join(' ')} ` : '';
+                                        infoMessages.push(
+                                                `${prefix}Falling back to ${fallbackDescription}.`.trim()
+                                        );
+                                }
+                        } else if (formattedFailures.length > 0) {
+                                infoMessages.push(...formattedFailures);
+                        }
+                }
 
 		if (fletchResult) {
 			await user.removeItemsFromBank(fletchResult.itemsToRemove);
 			const setsText = fletchResult.fletchable.outputMultiple ? ' sets of' : '';
-			const prefix =
-				fletchResult.preference.role === 'fallback'
-					? 'Using fallback preference, your minion is'
-					: 'Your minion is';
+                        const prefix =
+                                fletchResult.preference.role === 'fallback'
+                                        ? 'Using fallback preference, your minion is'
+                                        : 'Your minion is';
 			response += `\n\n${prefix} fletching ${fletchResult.quantity}${setsText} ${fletchResult.fletchable.name} while training. Removed ${fletchResult.itemsToRemove} from your bank.`;
 		}
 
 		if (alchResult) {
 			await user.removeItemsFromBank(alchResult.bankToRemove);
-			const prefix =
-				alchResult.preference.role === 'fallback'
-					? 'Using fallback preference, your minion is'
-					: 'Your minion is';
+                        const prefix =
+                                alchResult.preference.role === 'fallback'
+                                        ? 'Using fallback preference, your minion is'
+                                        : 'Your minion is';
 			response += `\n\n${prefix} alching ${alchResult.quantity}x ${alchResult.item.name} while training. Removed ${alchResult.bankToRemove} from your bank.`;
 			updateBankSetting('magic_cost_bank', alchResult.bankToRemove);
 		}
 
-		if (infoMessages.length > 0) {
-			response += `\n\n${infoMessages.join('
-')}`;
-		}
+                if (infoMessages.length > 0) {
+                        response += `\n\n${infoMessages.join('\n')}`;
+                }
 
-		const zeroTimePreferenceRole = fletchResult?.preference.role ?? alchResult?.preference.role ?? null;
+                const zeroTimePreferenceRole = fletchResult?.preference.role ?? alchResult?.preference.role ?? null;
 
 		await addSubTaskToActivityTask<AgilityActivityTaskOptions>({
 			courseID: course.id,

--- a/tests/integration/commands/zeroTimeActivity.test.ts
+++ b/tests/integration/commands/zeroTimeActivity.test.ts
@@ -3,16 +3,16 @@ import { describe, expect, test } from 'vitest';
 
 import { zeroTimeFletchables } from '../../../src/lib/skilling/skills/fletching/fletchables';
 import {
-	attemptZeroTimeActivity,
-	getZeroTimeActivityPreferences,
-	type ZeroTimeActivityPreference
+        attemptZeroTimeActivity,
+        getZeroTimeActivityPreferences,
+        type ZeroTimeActivityPreference
 } from '../../../src/lib/util/zeroTimeActivity';
 import { zeroTimeActivityCommand } from '../../../src/mahoji/commands/zeroTimeActivity';
 import { timePerAlch } from '../../../src/mahoji/lib/abstracted_commands/alchCommand';
 import { createTestUser } from '../util';
 
 describe('Zero Time Activity Command', () => {
-	const automaticSelectionText = 'automatic selection from your favourite alchs each trip';
+        const automaticSelectionText = 'Primary: Alch (automatic favourites)';
 
 	test('persists alching configuration and uses it', async () => {
 		const item = Items.getOrThrow('Yew longbow');
@@ -27,28 +27,29 @@ describe('Zero Time Activity Command', () => {
 			}
 		});
 
-		expect(response).toContain('Primary: **Alching**');
+                expect(response).toContain('Primary: Alch Yew longbow');
 		await user.sync();
 		expect(user.user.zero_time_activity_primary_type).toBe('alch');
 		expect(user.user.zero_time_activity_primary_item).toBe(item.id);
 		expect(user.user.zero_time_activity_fallback_type).toBeNull();
 
-		const summary = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
-		expect(summary).toContain('Primary: **Alching** using **Yew longbow**');
+                const summary = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
+                expect(summary).toContain('Primary: Alch Yew longbow');
 
 		const [preference] = getZeroTimeActivityPreferences(user);
 		expect(preference).toEqual<ZeroTimeActivityPreference>({ role: 'primary', type: 'alch', itemID: item.id });
 
 		const duration = timePerAlch * 5;
-		const activity = attemptZeroTimeActivity({
-			user,
-			duration,
-			preference,
-			variant: 'default'
-		});
+                const activity = attemptZeroTimeActivity({
+                        user,
+                        duration,
+                        preferences: [preference],
+                        alch: { variant: 'default' }
+                });
 
-		expect(activity.result?.type).toBe('alch');
-		expect(activity.result && activity.result.type === 'alch' ? activity.result.quantity : null).toBe(5);
+                expect(activity.failures).toHaveLength(0);
+                expect(activity.result?.type).toBe('alch');
+                expect(activity.result && activity.result.type === 'alch' ? activity.result.quantity : null).toBe(5);
 	});
 
 	test('allows automatic alch selection', async () => {
@@ -62,14 +63,14 @@ describe('Zero Time Activity Command', () => {
 			}
 		});
 
-		expect(response).toContain(automaticSelectionText);
+                expect(response).toContain(automaticSelectionText);
 		await user.sync();
 		expect(user.user.zero_time_activity_primary_type).toBe('alch');
 		expect(user.user.zero_time_activity_primary_item).toBeNull();
 		expect(user.user.zero_time_activity_fallback_type).toBeNull();
 
-		const summary = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
-		expect(summary).toContain(`Primary: **Alching** using **${automaticSelectionText}**`);
+                const summary = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
+                expect(summary).toContain(automaticSelectionText);
 	});
 
 	test('reuses configured fletching item on subsequent calls', async () => {
@@ -135,7 +136,7 @@ describe('Zero Time Activity Command', () => {
 			{ role: 'fallback', type: 'fletch', itemID: fletchable.id }
 		]);
 
-		const overview = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
-		expect(overview).toContain('Fallback: **Fletching**');
+                const overview = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
+                expect(overview).toContain('Fallback: Fletch Steel dart');
 	});
 });

--- a/tests/unit/zeroTimeActivity.test.ts
+++ b/tests/unit/zeroTimeActivity.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, test } from 'vitest';
 
 import { zeroTimeFletchables } from '../../src/lib/skilling/skills/fletching/fletchables';
 import {
-	attemptZeroTimeActivity,
-	getZeroTimeFletchTime,
-	type ZeroTimeActivityPreference
+        attemptZeroTimeActivity,
+        getZeroTimeFletchTime,
+        type ZeroTimeActivityPreference
 } from '../../src/lib/util/zeroTimeActivity';
 import { timePerAlch } from '../../src/mahoji/lib/abstracted_commands/alchCommand';
 import { mockMUser } from './userutil';
@@ -21,16 +21,16 @@ describe('attemptZeroTimeActivity', () => {
 		});
 
 		const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'alch', itemID: item.id };
-		const response = attemptZeroTimeActivity({
-			user,
-			duration,
-			preference,
-			variant: 'default'
-		});
+                const response = attemptZeroTimeActivity({
+                        user,
+                        duration,
+                        preferences: [preference],
+                        alch: { variant: 'default' }
+                });
 
-		expect(response.message).toBeUndefined();
-		expect(response.result?.type).toBe('alch');
-		if (!response.result || response.result.type !== 'alch') return;
+                expect(response.failures).toHaveLength(0);
+                expect(response.result?.type).toBe('alch');
+                if (!response.result || response.result.type !== 'alch') return;
 
 		expect(response.result.quantity).toBe(50);
 		const expectedRemove = new Bank().add('Nature rune', 50).add('Fire rune', 250).add(item.id, 50);
@@ -52,13 +52,12 @@ describe('attemptZeroTimeActivity', () => {
 		});
 
 		const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'alch', itemID: item.id };
-		const response = attemptZeroTimeActivity({
-			user,
-			duration,
-			preference,
-			variant: 'default',
-			itemsPerHour: ratePerHour
-		});
+                const response = attemptZeroTimeActivity({
+                        user,
+                        duration,
+                        preferences: [preference],
+                        alch: { variant: 'default', itemsPerHour: ratePerHour }
+                });
 
 		expect(response.result?.type).toBe('alch');
 		if (!response.result || response.result.type !== 'alch') return;
@@ -75,15 +74,15 @@ describe('attemptZeroTimeActivity', () => {
 		});
 
 		const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'alch', itemID: item.id };
-		const response = attemptZeroTimeActivity({
-			user,
-			duration: timePerAlch * 10,
-			preference,
-			variant: 'default'
-		});
+                const response = attemptZeroTimeActivity({
+                        user,
+                        duration: timePerAlch * 10,
+                        preferences: [preference],
+                        alch: { variant: 'default' }
+                });
 
-		expect(response.result).toBeNull();
-		expect(response.message).toBe("You're missing resources to alch Yew longbow.");
+                expect(response.result).toBeNull();
+                expect(response.failures[0]?.message).toBe("You're missing resources to alch Yew longbow.");
 	});
 
 	test('fletching success', () => {
@@ -98,15 +97,15 @@ describe('attemptZeroTimeActivity', () => {
 		});
 
 		const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'fletch', itemID: fletchable.id };
-		const response = attemptZeroTimeActivity({
-			user,
-			duration,
-			preference
-		});
+                const response = attemptZeroTimeActivity({
+                        user,
+                        duration,
+                        preferences: [preference]
+                });
 
-		expect(response.message).toBeUndefined();
-		expect(response.result?.type).toBe('fletch');
-		if (!response.result || response.result.type !== 'fletch') return;
+                expect(response.failures).toHaveLength(0);
+                expect(response.result?.type).toBe('fletch');
+                if (!response.result || response.result.type !== 'fletch') return;
 
 		expect(response.result.quantity).toBe(200);
 		const expectedRemove = fletchable.inputItems.clone().multiply(200);
@@ -138,13 +137,14 @@ describe('attemptZeroTimeActivity', () => {
 			});
 			const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'fletch', itemID: fletchable.id };
 
-			const baseResponse = attemptZeroTimeActivity({
-				user: baseUser,
-				duration,
-				preference
-			});
+                        const baseResponse = attemptZeroTimeActivity({
+                                user: baseUser,
+                                duration,
+                                preferences: [preference]
+                        });
 
-			expect(baseResponse.result?.type).toBe('fletch');
+                        expect(baseResponse.failures).toHaveLength(0);
+                        expect(baseResponse.result?.type).toBe('fletch');
 			if (!baseResponse.result || baseResponse.result.type !== 'fletch') return;
 
 			expect(baseResponse.result.quantity).toBe(defaultSets);
@@ -157,14 +157,15 @@ describe('attemptZeroTimeActivity', () => {
 				skills_fletching: convertLVLtoXP(70)
 			});
 
-			const overrideResponse = attemptZeroTimeActivity({
-				user: overrideUser,
-				duration,
-				preference,
-				itemsPerHour
-			});
+                        const overrideResponse = attemptZeroTimeActivity({
+                                user: overrideUser,
+                                duration,
+                                preferences: [preference],
+                                fletch: { itemsPerHour }
+                        });
 
-			expect(overrideResponse.result?.type).toBe('fletch');
+                        expect(overrideResponse.failures).toHaveLength(0);
+                        expect(overrideResponse.result?.type).toBe('fletch');
 			if (!overrideResponse.result || overrideResponse.result.type !== 'fletch') return;
 
 			expect(overrideResponse.result.quantity).toBe(baseResponse.result.quantity);
@@ -200,13 +201,15 @@ describe('attemptZeroTimeActivity', () => {
 		});
 
 		const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'fletch', itemID: fletchable.id };
-		const response = attemptZeroTimeActivity({
-			user,
-			duration: Time.Second * 10,
-			preference
-		});
+                const response = attemptZeroTimeActivity({
+                        user,
+                        duration: Time.Second * 10,
+                        preferences: [preference]
+                });
 
-		expect(response.result).toBeNull();
-		expect(response.message).toBe("You don't have the required Slayer unlocks to fletch Broad arrows.");
+                expect(response.result).toBeNull();
+                expect(response.failures[0]?.message).toBe(
+                        "You don't have the required Slayer unlocks to fletch Broad arrows."
+                );
 	});
 });


### PR DESCRIPTION
## Summary
- add ordered zero-time preference helpers that support primary and fallback actions with richer labels and availability checks
- update zero-time commands, laps, and Sepulchre flows to surface availability info, automatically fall back when the primary action is blocked, and refresh related docs
- extend unit and integration coverage for the new helper signatures and command UX changes

## Testing
- pnpm vitest run tests/unit/zeroTimeActivity.test.ts *(fails: Vite cannot resolve @oldschoolgg/toolkit in this environment)*
- pnpm vitest run tests/integration/commands/zeroTimeActivity.test.ts *(fails: Vite cannot resolve oldschooljs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dda055a7dc8326835aa3f98946ea4d