### PR TITLE
Fix Biome formatting for zero-time activity modules

### DIFF
--- a/src/lib/util/zeroTimeActivity.ts
+++ b/src/lib/util/zeroTimeActivity.ts
@@ -47,83 +47,83 @@ export type ZeroTimeActivityResult =
 	  };
 
 export interface ZeroTimeActivityResponse {
-        result: ZeroTimeActivityResult | null;
-        message?: string;
+	result: ZeroTimeActivityResult | null;
+	message?: string;
 }
 
 interface BaseAttemptZeroTimeActivityOptions {
-        user: MUser;
-        duration: number;
-        preference: ZeroTimeActivityPreference;
-        quantityOverride?: number;
-        itemsPerHour?: number;
+	user: MUser;
+	duration: number;
+	preference: ZeroTimeActivityPreference;
+	quantityOverride?: number;
+	itemsPerHour?: number;
 }
 
 export interface AttemptZeroTimeAlchOptions extends BaseAttemptZeroTimeActivityOptions {
-        preference: ZeroTimeActivityPreference & { type: 'alch' };
-        variant?: 'agility' | 'default';
+	preference: ZeroTimeActivityPreference & { type: 'alch' };
+	variant?: 'agility' | 'default';
 }
 
 export interface AttemptZeroTimeFletchOptions extends BaseAttemptZeroTimeActivityOptions {
-        preference: ZeroTimeActivityPreference & { type: 'fletch' };
+	preference: ZeroTimeActivityPreference & { type: 'fletch' };
 }
 
 type ItemsPerHourResolver = number | ((preference: ZeroTimeActivityPreference) => number | undefined);
 
 interface AttemptZeroTimeContextBase {
-        disabledReason?: string;
-        itemsPerHour?: ItemsPerHourResolver;
+	disabledReason?: string;
+	itemsPerHour?: ItemsPerHourResolver;
 }
 
 export interface AttemptZeroTimeAlchContext extends AttemptZeroTimeContextBase {
-        variant?: 'agility' | 'default';
+	variant?: 'agility' | 'default';
 }
 
 export type AttemptZeroTimeFletchContext = AttemptZeroTimeContextBase;
 
 export interface AttemptZeroTimeActivityOptions {
-        user: MUser;
-        duration: number;
-        preferences: ZeroTimePreferenceList;
-        quantityOverride?: number;
-        alch?: AttemptZeroTimeAlchContext;
-        fletch?: AttemptZeroTimeFletchContext;
+	user: MUser;
+	duration: number;
+	preferences: ZeroTimePreferenceList;
+	quantityOverride?: number;
+	alch?: AttemptZeroTimeAlchContext;
+	fletch?: AttemptZeroTimeFletchContext;
 }
 
 export interface AttemptZeroTimeActivityFailure {
-        preference: ZeroTimeActivityPreference;
-        message?: string;
+	preference: ZeroTimeActivityPreference;
+	message?: string;
 }
 
 export interface AttemptZeroTimeActivityOutcome {
-        result: ZeroTimeActivityResult | null;
-        failures: AttemptZeroTimeActivityFailure[];
+	result: ZeroTimeActivityResult | null;
+	failures: AttemptZeroTimeActivityFailure[];
 }
 
 export function getZeroTimePreferenceLabel(preference: ZeroTimeActivityPreference): string {
-        const roleLabel = preference.role === 'primary' ? 'Primary' : 'Fallback';
-        const typeLabel = preference.type === 'alch' ? 'alch' : 'fletch';
-        return `${roleLabel} ${typeLabel}`;
+	const roleLabel = preference.role === 'primary' ? 'Primary' : 'Fallback';
+	const typeLabel = preference.type === 'alch' ? 'alch' : 'fletch';
+	return `${roleLabel} ${typeLabel}`;
 }
 
 export function describeZeroTimePreference(preference: ZeroTimeActivityPreference): string {
-        if (preference.type === 'alch') {
-                if (!preference.itemID) {
-                        return 'Alch (automatic favourites)';
-                }
-                const item = Items.get(preference.itemID);
-                const itemName = item?.name ?? 'unknown item';
-                return `Alch ${itemName}`;
-        }
+	if (preference.type === 'alch') {
+		if (!preference.itemID) {
+			return 'Alch (automatic favourites)';
+		}
+		const item = Items.get(preference.itemID);
+		const itemName = item?.name ?? 'unknown item';
+		return `Alch ${itemName}`;
+	}
 
-        const item = preference.itemID ? Items.get(preference.itemID) : null;
-        const itemName = item?.name ?? 'unspecified fletchable';
-        return `Fletch ${itemName}`;
+	const item = preference.itemID ? Items.get(preference.itemID) : null;
+	const itemName = item?.name ?? 'unspecified fletchable';
+	return `Fletch ${itemName}`;
 }
 
 export function formatZeroTimePreference(preference: ZeroTimeActivityPreference): string {
-        const roleLabel = preference.role === 'primary' ? 'Primary' : 'Fallback';
-        return `${roleLabel}: ${describeZeroTimePreference(preference)}`;
+	const roleLabel = preference.role === 'primary' ? 'Primary' : 'Fallback';
+	return `${roleLabel}: ${describeZeroTimePreference(preference)}`;
 }
 
 export function getZeroTimeActivityPreferences(user: MUser): ZeroTimePreferenceList {
@@ -390,74 +390,74 @@ function calculateFletching(options: AttemptZeroTimeFletchOptions): ZeroTimeActi
 }
 
 function attemptZeroTimePreference(
-        options: AttemptZeroTimeAlchOptions | AttemptZeroTimeFletchOptions
+	options: AttemptZeroTimeAlchOptions | AttemptZeroTimeFletchOptions
 ): ZeroTimeActivityResponse {
-        if (options.preference.type === 'alch') {
-                return calculateAlching(options);
-        }
+	if (options.preference.type === 'alch') {
+		return calculateAlching(options);
+	}
 
-        return calculateFletching(options);
+	return calculateFletching(options);
 }
 
 export function attemptZeroTimeActivity(options: AttemptZeroTimeActivityOptions): AttemptZeroTimeActivityOutcome {
-        const failures: AttemptZeroTimeActivityFailure[] = [];
+	const failures: AttemptZeroTimeActivityFailure[] = [];
 
-        const resolveItemsPerHour = (
-                resolver: ItemsPerHourResolver | undefined,
-                preference: ZeroTimeActivityPreference
-        ): number | undefined => {
-                if (typeof resolver === 'function') {
-                        return resolver(preference);
-                }
-                return resolver;
-        };
+	const resolveItemsPerHour = (
+		resolver: ItemsPerHourResolver | undefined,
+		preference: ZeroTimeActivityPreference
+	): number | undefined => {
+		if (typeof resolver === 'function') {
+			return resolver(preference);
+		}
+		return resolver;
+	};
 
-        for (const preference of options.preferences) {
-                if (preference.type === 'alch') {
-                        if (options.alch?.disabledReason) {
-                                failures.push({ preference, message: options.alch.disabledReason });
-                                continue;
-                        }
-                        const attempt = attemptZeroTimePreference({
-                                user: options.user,
-                                duration: options.duration,
-                                preference: preference as ZeroTimeActivityPreference & { type: 'alch' },
-                                quantityOverride: options.quantityOverride,
-                                itemsPerHour: resolveItemsPerHour(options.alch?.itemsPerHour, preference),
-                                variant: options.alch?.variant
-                        });
+	for (const preference of options.preferences) {
+		if (preference.type === 'alch') {
+			if (options.alch?.disabledReason) {
+				failures.push({ preference, message: options.alch.disabledReason });
+				continue;
+			}
+			const attempt = attemptZeroTimePreference({
+				user: options.user,
+				duration: options.duration,
+				preference: preference as ZeroTimeActivityPreference & { type: 'alch' },
+				quantityOverride: options.quantityOverride,
+				itemsPerHour: resolveItemsPerHour(options.alch?.itemsPerHour, preference),
+				variant: options.alch?.variant
+			});
 
-                        if (attempt.result) {
-                                return { result: attempt.result, failures };
-                        }
+			if (attempt.result) {
+				return { result: attempt.result, failures };
+			}
 
-                        if (attempt.message) {
-                                failures.push({ preference, message: attempt.message });
-                        }
-                        continue;
-                }
+			if (attempt.message) {
+				failures.push({ preference, message: attempt.message });
+			}
+			continue;
+		}
 
-                if (options.fletch?.disabledReason) {
-                        failures.push({ preference, message: options.fletch.disabledReason });
-                        continue;
-                }
+		if (options.fletch?.disabledReason) {
+			failures.push({ preference, message: options.fletch.disabledReason });
+			continue;
+		}
 
-                const attempt = attemptZeroTimePreference({
-                        user: options.user,
-                        duration: options.duration,
-                        preference: preference as ZeroTimeActivityPreference & { type: 'fletch' },
-                        quantityOverride: options.quantityOverride,
-                        itemsPerHour: resolveItemsPerHour(options.fletch?.itemsPerHour, preference)
-                });
+		const attempt = attemptZeroTimePreference({
+			user: options.user,
+			duration: options.duration,
+			preference: preference as ZeroTimeActivityPreference & { type: 'fletch' },
+			quantityOverride: options.quantityOverride,
+			itemsPerHour: resolveItemsPerHour(options.fletch?.itemsPerHour, preference)
+		});
 
-                if (attempt.result) {
-                        return { result: attempt.result, failures };
-                }
+		if (attempt.result) {
+			return { result: attempt.result, failures };
+		}
 
-                if (attempt.message) {
-                        failures.push({ preference, message: attempt.message });
-                }
-        }
+		if (attempt.message) {
+			failures.push({ preference, message: attempt.message });
+		}
+	}
 
-        return { result: null, failures };
+	return { result: null, failures };
 }

--- a/src/mahoji/commands/laps.ts
+++ b/src/mahoji/commands/laps.ts
@@ -8,11 +8,11 @@ import addSubTaskToActivityTask from '@/lib/util/addSubTaskToActivityTask.js';
 import { calcMaxTripLength } from '@/lib/util/calcMaxTripLength.js';
 import { updateBankSetting } from '@/lib/util/updateBankSetting.js';
 import {
-        attemptZeroTimeActivity,
-        describeZeroTimePreference,
-        getZeroTimeActivityPreferences,
-        getZeroTimePreferenceLabel,
-        type ZeroTimeActivityResult
+	attemptZeroTimeActivity,
+	describeZeroTimePreference,
+	getZeroTimeActivityPreferences,
+	getZeroTimePreferenceLabel,
+	type ZeroTimeActivityResult
 } from '@/lib/util/zeroTimeActivity.js';
 import { timePerAlchAgility } from '@/mahoji/lib/abstracted_commands/alchCommand.js';
 
@@ -105,79 +105,72 @@ export const lapsCommand: OSBMahojiCommand = {
 		let fletchResult: FletchResult | null = null;
 		let alchResult: AlchResult | null = null;
 		const infoMessages: string[] = [];
-                const preferences = getZeroTimeActivityPreferences(user);
+		const preferences = getZeroTimeActivityPreferences(user);
 
-                if (preferences.length > 0) {
-                        const alchDisabledReason =
-                                course.name === 'Ape Atoll Agility Course'
-                                        ? 'Alching is unavailable on this course because your minion must hold a greegree.'
-                                        : undefined;
+		if (preferences.length > 0) {
+			const alchDisabledReason =
+				course.name === 'Ape Atoll Agility Course'
+					? 'Alching is unavailable on this course because your minion must hold a greegree.'
+					: undefined;
 
-                        const outcome = attemptZeroTimeActivity({
-                                user,
-                                duration,
-                                preferences,
-                                alch: {
-                                        variant: 'agility',
-                                        itemsPerHour: AGILITY_ALCHES_PER_HOUR,
-                                        ...(alchDisabledReason ? { disabledReason: alchDisabledReason } : {})
-                                },
-                                fletch: { itemsPerHour: AGILITY_FLETCH_ITEMS_PER_HOUR }
-                        });
+			const outcome = attemptZeroTimeActivity({
+				user,
+				duration,
+				preferences,
+				alch: {
+					variant: 'agility',
+					itemsPerHour: AGILITY_ALCHES_PER_HOUR,
+					...(alchDisabledReason ? { disabledReason: alchDisabledReason } : {})
+				},
+				fletch: { itemsPerHour: AGILITY_FLETCH_ITEMS_PER_HOUR }
+			});
 
-                        if (outcome.result?.type === 'fletch') {
-                                fletchResult = outcome.result;
-                        } else if (outcome.result?.type === 'alch') {
-                                alchResult = outcome.result;
-                        }
+			if (outcome.result?.type === 'fletch') {
+				fletchResult = outcome.result;
+			} else if (outcome.result?.type === 'alch') {
+				alchResult = outcome.result;
+			}
 
-                        const formattedFailures = outcome.failures
-                                .filter(failure => failure.message)
-                                .map(
-                                        failure =>
-                                                `${getZeroTimePreferenceLabel(failure.preference)}: ${failure.message}`
-                                );
+			const formattedFailures = outcome.failures
+				.filter(failure => failure.message)
+				.map(failure => `${getZeroTimePreferenceLabel(failure.preference)}: ${failure.message}`);
 
-                        if (outcome.result) {
-                                if (outcome.result.preference.role === 'fallback') {
-                                        const fallbackDescription = describeZeroTimePreference(
-                                                outcome.result.preference
-                                        );
-                                        const prefix = formattedFailures.length > 0 ? `${formattedFailures.join(' ')} ` : '';
-                                        infoMessages.push(
-                                                `${prefix}Falling back to ${fallbackDescription}.`.trim()
-                                        );
-                                }
-                        } else if (formattedFailures.length > 0) {
-                                infoMessages.push(...formattedFailures);
-                        }
-                }
+			if (outcome.result) {
+				if (outcome.result.preference.role === 'fallback') {
+					const fallbackDescription = describeZeroTimePreference(outcome.result.preference);
+					const prefix = formattedFailures.length > 0 ? `${formattedFailures.join(' ')} ` : '';
+					infoMessages.push(`${prefix}Falling back to ${fallbackDescription}.`.trim());
+				}
+			} else if (formattedFailures.length > 0) {
+				infoMessages.push(...formattedFailures);
+			}
+		}
 
 		if (fletchResult) {
 			await user.removeItemsFromBank(fletchResult.itemsToRemove);
 			const setsText = fletchResult.fletchable.outputMultiple ? ' sets of' : '';
-                        const prefix =
-                                fletchResult.preference.role === 'fallback'
-                                        ? 'Using fallback preference, your minion is'
-                                        : 'Your minion is';
+			const prefix =
+				fletchResult.preference.role === 'fallback'
+					? 'Using fallback preference, your minion is'
+					: 'Your minion is';
 			response += `\n\n${prefix} fletching ${fletchResult.quantity}${setsText} ${fletchResult.fletchable.name} while training. Removed ${fletchResult.itemsToRemove} from your bank.`;
 		}
 
 		if (alchResult) {
 			await user.removeItemsFromBank(alchResult.bankToRemove);
-                        const prefix =
-                                alchResult.preference.role === 'fallback'
-                                        ? 'Using fallback preference, your minion is'
-                                        : 'Your minion is';
+			const prefix =
+				alchResult.preference.role === 'fallback'
+					? 'Using fallback preference, your minion is'
+					: 'Your minion is';
 			response += `\n\n${prefix} alching ${alchResult.quantity}x ${alchResult.item.name} while training. Removed ${alchResult.bankToRemove} from your bank.`;
 			updateBankSetting('magic_cost_bank', alchResult.bankToRemove);
 		}
 
-                if (infoMessages.length > 0) {
-                        response += `\n\n${infoMessages.join('\n')}`;
-                }
+		if (infoMessages.length > 0) {
+			response += `\n\n${infoMessages.join('\n')}`;
+		}
 
-                const zeroTimePreferenceRole = fletchResult?.preference.role ?? alchResult?.preference.role ?? null;
+		const zeroTimePreferenceRole = fletchResult?.preference.role ?? alchResult?.preference.role ?? null;
 
 		await addSubTaskToActivityTask<AgilityActivityTaskOptions>({
 			courseID: course.id,

--- a/src/mahoji/commands/zeroTimeActivity.ts
+++ b/src/mahoji/commands/zeroTimeActivity.ts
@@ -6,47 +6,47 @@ import { zeroTimeFletchables } from '../../lib/skilling/skills/fletching/fletcha
 import { SlayerRewardsShop, type SlayerTaskUnlocksEnum } from '../../lib/slayer/slayerUnlocks';
 import { hasSlayerUnlock } from '../../lib/slayer/slayerUtil';
 import {
-        attemptZeroTimeActivity,
-        formatZeroTimePreference,
-        getZeroTimeActivityPreferences,
-        type ZeroTimeActivityPreference,
-        type ZeroTimeActivityType
+	attemptZeroTimeActivity,
+	formatZeroTimePreference,
+	getZeroTimeActivityPreferences,
+	type ZeroTimeActivityPreference,
+	type ZeroTimeActivityType
 } from '../../lib/util/zeroTimeActivity';
 
 const zeroTimeTypes: ZeroTimeActivityType[] = ['alch', 'fletch'];
 
 const slayerUnlockName = new Map<SlayerTaskUnlocksEnum, string>(
-        SlayerRewardsShop.map(unlock => [unlock.id, unlock.name])
+	SlayerRewardsShop.map(unlock => [unlock.id, unlock.name])
 );
 
 function describeFletchableRequirements(fletchable: (typeof zeroTimeFletchables)[number]): string {
-        const parts: string[] = [`${fletchable.level} Fletching`];
+	const parts: string[] = [`${fletchable.level} Fletching`];
 
-        if (fletchable.requiredSlayerUnlocks?.length) {
-                const unlockNames = fletchable.requiredSlayerUnlocks
-                        .map(unlock => slayerUnlockName.get(unlock))
-                        .filter((name): name is string => Boolean(name));
-                if (unlockNames.length > 0) {
-                        parts.push(`${unlockNames.join(', ')} unlock`);
-                }
-        }
+	if (fletchable.requiredSlayerUnlocks?.length) {
+		const unlockNames = fletchable.requiredSlayerUnlocks
+			.map(unlock => slayerUnlockName.get(unlock))
+			.filter((name): name is string => Boolean(name));
+		if (unlockNames.length > 0) {
+			parts.push(`${unlockNames.join(', ')} unlock`);
+		}
+	}
 
-        return parts.join(' · ');
+	return parts.join(' · ');
 }
 
 function getAutocompleteOptions(value: string) {
-        const trimmedValue = value.trim();
-        const search = trimmedValue.toLowerCase();
-        const curatedOptions = zeroTimeFletchables
-                .filter(fletchable =>
-                        search.length === 0
+	const trimmedValue = value.trim();
+	const search = trimmedValue.toLowerCase();
+	const curatedOptions = zeroTimeFletchables
+		.filter(fletchable =>
+			search.length === 0
 				? true
 				: fletchable.name.toLowerCase().includes(search) || fletchable.id.toString() === search
 		)
-                .map(fletchable => ({
-                        name: `${fletchable.name} (${describeFletchableRequirements(fletchable)})`,
-                        value: fletchable.id.toString()
-                }));
+		.map(fletchable => ({
+			name: `${fletchable.name} (${describeFletchableRequirements(fletchable)})`,
+			value: fletchable.id.toString()
+		}));
 
 	const results: { name: string; value: string }[] = [];
 	if (trimmedValue.length > 0 && !curatedOptions.some(option => option.value === trimmedValue)) {
@@ -64,15 +64,15 @@ function getAutocompleteOptions(value: string) {
 }
 
 function parseAlchItemInput(
-        user: MUser,
-        itemInput: string | null,
-        context: 'primary' | 'fallback'
+	user: MUser,
+	itemInput: string | null,
+	context: 'primary' | 'fallback'
 ): { itemID: number | null; error?: string } {
-        if (!itemInput || itemInput.length === 0) {
-                return { itemID: null };
-        }
+	if (!itemInput || itemInput.length === 0) {
+		return { itemID: null };
+	}
 
-        const osItem = Items.get(itemInput);
+	const osItem = Items.get(itemInput);
 	if (!osItem) {
 		return { itemID: null, error: 'That is not a valid item to alch.' };
 	}
@@ -133,30 +133,30 @@ function buildOverview(user: MUser): string {
 	}
 
 	const lines: string[] = [];
-        for (const preference of preferences) {
-                const label = formatZeroTimePreference(preference);
+	for (const preference of preferences) {
+		const label = formatZeroTimePreference(preference);
 
-                const outcome = attemptZeroTimeActivity({
-                        user,
-                        duration: Time.Minute,
-                        preferences: [preference],
-                        quantityOverride: 1,
-                        alch: { variant: 'default' },
-                        fletch: {}
-                });
+		const outcome = attemptZeroTimeActivity({
+			user,
+			duration: Time.Minute,
+			preferences: [preference],
+			quantityOverride: 1,
+			alch: { variant: 'default' },
+			fletch: {}
+		});
 
-                if (outcome.result) {
-                        lines.push(`${label} -- Ready`);
-                        continue;
-                }
+		if (outcome.result) {
+			lines.push(`${label} -- Ready`);
+			continue;
+		}
 
-                const failure = outcome.failures[0];
-                if (failure?.message) {
-                        lines.push(`${label} -- ${failure.message}`);
-                } else {
-                        lines.push(`${label} -- Not currently available.`);
-                }
-        }
+		const failure = outcome.failures[0];
+		if (failure?.message) {
+			lines.push(`${label} -- ${failure.message}`);
+		} else {
+			lines.push(`${label} -- Not currently available.`);
+		}
+	}
 
 	return lines.join('\n');
 }
@@ -194,7 +194,10 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 					name: 'fallback_type',
 					description: 'Optional fallback zero-time activity type.',
 					required: false,
-					choices: [{ name: 'none', value: 'none' }, ...zeroTimeTypes.map(type => ({ name: type, value: type }))]
+					choices: [
+						{ name: 'none', value: 'none' },
+						...zeroTimeTypes.map(type => ({ name: type, value: type }))
+					]
 				},
 				{
 					type: ApplicationCommandOptionType.String,
@@ -211,7 +214,10 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 			description: 'Clear your zero-time activity preferences.'
 		}
 	],
-	run: async ({ options, userID }: CommandRunOptions<{
+	run: async ({
+		options,
+		userID
+	}: CommandRunOptions<{
 		overview?: Record<string, never>;
 		set?: {
 			primary_type: string;
@@ -220,16 +226,16 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 			fallback_item?: string | null;
 		};
 		clear?: Record<string, never>;
-        }>) => {
-                const user = await mUserFetch(userID);
+	}>) => {
+		const user = await mUserFetch(userID);
 
-                if (!options.overview && !options.set && !options.clear) {
-                        return buildOverview(user);
-                }
+		if (!options.overview && !options.set && !options.clear) {
+			return buildOverview(user);
+		}
 
-                if (options.overview) {
-                        return buildOverview(user);
-                }
+		if (options.overview) {
+			return buildOverview(user);
+		}
 
 		if (options.clear) {
 			await user.update({
@@ -279,10 +285,10 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 					return `Invalid fallback type. Valid options: ${zeroTimeTypes.join(', ')} or 'none'.`;
 				}
 
-                                fallbackType = fallbackInput as ZeroTimeActivityType;
+				fallbackType = fallbackInput as ZeroTimeActivityType;
 
-                                if (fallbackType === 'alch') {
-                                        const { itemID, error } = parseAlchItemInput(user, rawFallbackItem ?? null, 'fallback');
+				if (fallbackType === 'alch') {
+					const { itemID, error } = parseAlchItemInput(user, rawFallbackItem ?? null, 'fallback');
 					if (error) {
 						return error;
 					}
@@ -296,23 +302,23 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 				}
 			}
 
-                        if (fallbackType && fallbackType === primaryType && fallbackItemID === primaryItemID) {
-                                return 'Your fallback preference must be different from your primary preference.';
-                        }
+			if (fallbackType && fallbackType === primaryType && fallbackItemID === primaryItemID) {
+				return 'Your fallback preference must be different from your primary preference.';
+			}
 
-                        await user.update({
-                                zero_time_activity_primary_type: primaryType,
-                                zero_time_activity_primary_item: primaryItemID,
-                                zero_time_activity_fallback_type: fallbackType,
-                                zero_time_activity_fallback_item: fallbackItemID
-                        });
+			await user.update({
+				zero_time_activity_primary_type: primaryType,
+				zero_time_activity_primary_item: primaryItemID,
+				zero_time_activity_fallback_type: fallbackType,
+				zero_time_activity_fallback_item: fallbackItemID
+			});
 
-                        const refreshedUser = await mUserFetch(userID);
-                        const summaryLines = getZeroTimeActivityPreferences(refreshedUser).map(formatZeroTimePreference);
+			const refreshedUser = await mUserFetch(userID);
+			const summaryLines = getZeroTimeActivityPreferences(refreshedUser).map(formatZeroTimePreference);
 
-                        return `Saved your zero-time preferences.\n${summaryLines.join('\n')}`;
-                }
+			return `Saved your zero-time preferences.\n${summaryLines.join('\n')}`;
+		}
 
-                return 'Invalid zero-time activity command usage.';
-        }
+		return 'Invalid zero-time activity command usage.';
+	}
 };

--- a/src/mahoji/lib/abstracted_commands/sepulchreCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/sepulchreCommand.ts
@@ -7,13 +7,13 @@ import addSubTaskToActivityTask from '@/lib/util/addSubTaskToActivityTask.js';
 import { calcMaxTripLength } from '@/lib/util/calcMaxTripLength.js';
 import { updateBankSetting } from '@/lib/util/updateBankSetting.js';
 import {
-        attemptZeroTimeActivity,
-        describeZeroTimePreference,
-        getZeroTimeActivityPreferences,
-        getZeroTimeFletchTime,
-        getZeroTimePreferenceLabel,
-        type ZeroTimeActivityPreference,
-        type ZeroTimeActivityResult
+	attemptZeroTimeActivity,
+	describeZeroTimePreference,
+	getZeroTimeActivityPreferences,
+	getZeroTimeFletchTime,
+	getZeroTimePreferenceLabel,
+	type ZeroTimeActivityPreference,
+	type ZeroTimeActivityResult
 } from '@/lib/util/zeroTimeActivity.js';
 import { userHasGracefulEquipped } from '@/mahoji/mahojiSettings.js';
 
@@ -74,41 +74,38 @@ export async function sepulchreCommand(user: MUser, channelID: string) {
 	type AlchResult = Extract<ZeroTimeActivityResult, { type: 'alch' }>;
 	let fletchResult: FletchResult | null = null;
 	let alchResult: AlchResult | null = null;
-        const zeroTimeMessages: string[] = [];
-        const preferences = getZeroTimeActivityPreferences(user);
+	const zeroTimeMessages: string[] = [];
+	const preferences = getZeroTimeActivityPreferences(user);
 
-        if (preferences.length > 0) {
-                const outcome = attemptZeroTimeActivity({
-                        user,
-                        duration: tripLength,
-                        preferences,
-                        alch: { variant: 'default', itemsPerHour: SEPULCHRE_ALCHES_PER_HOUR },
-                        fletch: { itemsPerHour: preference => resolveFletchItemsPerHour(preference) }
-                });
+	if (preferences.length > 0) {
+		const outcome = attemptZeroTimeActivity({
+			user,
+			duration: tripLength,
+			preferences,
+			alch: { variant: 'default', itemsPerHour: SEPULCHRE_ALCHES_PER_HOUR },
+			fletch: { itemsPerHour: preference => resolveFletchItemsPerHour(preference) }
+		});
 
-                if (outcome.result?.type === 'fletch') {
-                        fletchResult = outcome.result;
-                } else if (outcome.result?.type === 'alch') {
-                        alchResult = outcome.result;
-                }
+		if (outcome.result?.type === 'fletch') {
+			fletchResult = outcome.result;
+		} else if (outcome.result?.type === 'alch') {
+			alchResult = outcome.result;
+		}
 
-                const formattedFailures = outcome.failures
-                        .filter(failure => failure.message)
-                        .map(
-                                failure =>
-                                        `${getZeroTimePreferenceLabel(failure.preference)}: ${failure.message}`
-                        );
+		const formattedFailures = outcome.failures
+			.filter(failure => failure.message)
+			.map(failure => `${getZeroTimePreferenceLabel(failure.preference)}: ${failure.message}`);
 
-                if (outcome.result) {
-                        if (outcome.result.preference.role === 'fallback') {
-                                const fallbackDescription = describeZeroTimePreference(outcome.result.preference);
-                                const prefix = formattedFailures.length > 0 ? `${formattedFailures.join(' ')} ` : '';
-                                zeroTimeMessages.push(`${prefix}Falling back to ${fallbackDescription}.`.trim());
-                        }
-                } else if (formattedFailures.length > 0) {
-                        zeroTimeMessages.push(...formattedFailures);
-                }
-        }
+		if (outcome.result) {
+			if (outcome.result.preference.role === 'fallback') {
+				const fallbackDescription = describeZeroTimePreference(outcome.result.preference);
+				const prefix = formattedFailures.length > 0 ? `${formattedFailures.join(' ')} ` : '';
+				zeroTimeMessages.push(`${prefix}Falling back to ${fallbackDescription}.`.trim());
+			}
+		} else if (formattedFailures.length > 0) {
+			zeroTimeMessages.push(...formattedFailures);
+		}
+	}
 
 	if (fletchResult) {
 		await user.removeItemsFromBank(fletchResult.itemsToRemove);
@@ -119,7 +116,7 @@ export async function sepulchreCommand(user: MUser, channelID: string) {
 		updateBankSetting('magic_cost_bank', alchResult.bankToRemove);
 	}
 
-        const zeroTimePreferenceRole = fletchResult?.preference.role ?? alchResult?.preference.role ?? null;
+	const zeroTimePreferenceRole = fletchResult?.preference.role ?? alchResult?.preference.role ?? null;
 
 	await addSubTaskToActivityTask<SepulchreActivityTaskOptions>({
 		floors: completableFloors.map(f => f.number),

--- a/tests/integration/commands/zeroTimeActivity.test.ts
+++ b/tests/integration/commands/zeroTimeActivity.test.ts
@@ -3,16 +3,16 @@ import { describe, expect, test } from 'vitest';
 
 import { zeroTimeFletchables } from '../../../src/lib/skilling/skills/fletching/fletchables';
 import {
-        attemptZeroTimeActivity,
-        getZeroTimeActivityPreferences,
-        type ZeroTimeActivityPreference
+	attemptZeroTimeActivity,
+	getZeroTimeActivityPreferences,
+	type ZeroTimeActivityPreference
 } from '../../../src/lib/util/zeroTimeActivity';
 import { zeroTimeActivityCommand } from '../../../src/mahoji/commands/zeroTimeActivity';
 import { timePerAlch } from '../../../src/mahoji/lib/abstracted_commands/alchCommand';
 import { createTestUser } from '../util';
 
 describe('Zero Time Activity Command', () => {
-        const automaticSelectionText = 'Primary: Alch (automatic favourites)';
+	const automaticSelectionText = 'Primary: Alch (automatic favourites)';
 
 	test('persists alching configuration and uses it', async () => {
 		const item = Items.getOrThrow('Yew longbow');
@@ -27,29 +27,29 @@ describe('Zero Time Activity Command', () => {
 			}
 		});
 
-                expect(response).toContain('Primary: Alch Yew longbow');
+		expect(response).toContain('Primary: Alch Yew longbow');
 		await user.sync();
 		expect(user.user.zero_time_activity_primary_type).toBe('alch');
 		expect(user.user.zero_time_activity_primary_item).toBe(item.id);
 		expect(user.user.zero_time_activity_fallback_type).toBeNull();
 
-                const summary = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
-                expect(summary).toContain('Primary: Alch Yew longbow');
+		const summary = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
+		expect(summary).toContain('Primary: Alch Yew longbow');
 
 		const [preference] = getZeroTimeActivityPreferences(user);
 		expect(preference).toEqual<ZeroTimeActivityPreference>({ role: 'primary', type: 'alch', itemID: item.id });
 
 		const duration = timePerAlch * 5;
-                const activity = attemptZeroTimeActivity({
-                        user,
-                        duration,
-                        preferences: [preference],
-                        alch: { variant: 'default' }
-                });
+		const activity = attemptZeroTimeActivity({
+			user,
+			duration,
+			preferences: [preference],
+			alch: { variant: 'default' }
+		});
 
-                expect(activity.failures).toHaveLength(0);
-                expect(activity.result?.type).toBe('alch');
-                expect(activity.result && activity.result.type === 'alch' ? activity.result.quantity : null).toBe(5);
+		expect(activity.failures).toHaveLength(0);
+		expect(activity.result?.type).toBe('alch');
+		expect(activity.result && activity.result.type === 'alch' ? activity.result.quantity : null).toBe(5);
 	});
 
 	test('allows automatic alch selection', async () => {
@@ -63,14 +63,14 @@ describe('Zero Time Activity Command', () => {
 			}
 		});
 
-                expect(response).toContain(automaticSelectionText);
+		expect(response).toContain(automaticSelectionText);
 		await user.sync();
 		expect(user.user.zero_time_activity_primary_type).toBe('alch');
 		expect(user.user.zero_time_activity_primary_item).toBeNull();
 		expect(user.user.zero_time_activity_fallback_type).toBeNull();
 
-                const summary = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
-                expect(summary).toContain(automaticSelectionText);
+		const summary = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
+		expect(summary).toContain(automaticSelectionText);
 	});
 
 	test('reuses configured fletching item on subsequent calls', async () => {
@@ -136,7 +136,7 @@ describe('Zero Time Activity Command', () => {
 			{ role: 'fallback', type: 'fletch', itemID: fletchable.id }
 		]);
 
-                const overview = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
-                expect(overview).toContain('Fallback: Fletch Steel dart');
+		const overview = await user.runCommand(zeroTimeActivityCommand, { overview: {} });
+		expect(overview).toContain('Fallback: Fletch Steel dart');
 	});
 });

--- a/tests/unit/userutil.ts
+++ b/tests/unit/userutil.ts
@@ -47,7 +47,7 @@ export interface MockUserArgs {
 const mockUser = (overrides?: MockUserArgs): User => {
 	const gearMelee = filterGearSetup(overrides?.meleeGear);
 	const cl = new Bank().add(overrides?.cl ?? {});
-	const _r = {
+	const r = {
 		cl,
 		gear_fashion: new Gear().raw() as Prisma.JsonValue,
 		gear_mage: new Gear().raw() as Prisma.JsonValue,
@@ -90,18 +90,16 @@ const mockUser = (overrides?: MockUserArgs): User => {
 		id: overrides?.id ?? '',
 		monsterScores: {},
 		badges: [],
-	\tzero_time_activity_primary_type: overrides?.zero_time_activity_primary_type ?? null,
-	\tzero_time_activity_primary_item: overrides?.zero_time_activity_primary_item ?? null,
-	\tzero_time_activity_fallback_type: overrides?.zero_time_activity_fallback_type ?? null,
-	\tzero_time_activity_fallback_item: overrides?.zero_time_activity_fallback_item ?? null,
+		zero_time_activity_primary_type: overrides?.zero_time_activity_primary_type ?? null,
+		zero_time_activity_primary_item: overrides?.zero_time_activity_primary_item ?? null,
+		zero_time_activity_fallback_type: overrides?.zero_time_activity_fallback_type ?? null,
+		zero_time_activity_fallback_item: overrides?.zero_time_activity_fallback_item ?? null,
 		favorite_alchables: overrides?.favorite_alchables ?? [],
 		slayer_unlocks: overrides?.slayer_unlocks ?? []
-};
-as;
-unknown as User;
+	} as unknown as User;
 
-return r;
-}
+	return r;
+};
 
 export const mockMUser = (overrides?: MockUserArgs) => {
 	const user = new MUserClass(mockUser(overrides));

--- a/tests/unit/zeroTimeActivity.test.ts
+++ b/tests/unit/zeroTimeActivity.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, test } from 'vitest';
 
 import { zeroTimeFletchables } from '../../src/lib/skilling/skills/fletching/fletchables';
 import {
-        attemptZeroTimeActivity,
-        getZeroTimeFletchTime,
-        type ZeroTimeActivityPreference
+	attemptZeroTimeActivity,
+	getZeroTimeFletchTime,
+	type ZeroTimeActivityPreference
 } from '../../src/lib/util/zeroTimeActivity';
 import { timePerAlch } from '../../src/mahoji/lib/abstracted_commands/alchCommand';
 import { mockMUser } from './userutil';
@@ -21,16 +21,16 @@ describe('attemptZeroTimeActivity', () => {
 		});
 
 		const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'alch', itemID: item.id };
-                const response = attemptZeroTimeActivity({
-                        user,
-                        duration,
-                        preferences: [preference],
-                        alch: { variant: 'default' }
-                });
+		const response = attemptZeroTimeActivity({
+			user,
+			duration,
+			preferences: [preference],
+			alch: { variant: 'default' }
+		});
 
-                expect(response.failures).toHaveLength(0);
-                expect(response.result?.type).toBe('alch');
-                if (!response.result || response.result.type !== 'alch') return;
+		expect(response.failures).toHaveLength(0);
+		expect(response.result?.type).toBe('alch');
+		if (!response.result || response.result.type !== 'alch') return;
 
 		expect(response.result.quantity).toBe(50);
 		const expectedRemove = new Bank().add('Nature rune', 50).add('Fire rune', 250).add(item.id, 50);
@@ -52,12 +52,12 @@ describe('attemptZeroTimeActivity', () => {
 		});
 
 		const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'alch', itemID: item.id };
-                const response = attemptZeroTimeActivity({
-                        user,
-                        duration,
-                        preferences: [preference],
-                        alch: { variant: 'default', itemsPerHour: ratePerHour }
-                });
+		const response = attemptZeroTimeActivity({
+			user,
+			duration,
+			preferences: [preference],
+			alch: { variant: 'default', itemsPerHour: ratePerHour }
+		});
 
 		expect(response.result?.type).toBe('alch');
 		if (!response.result || response.result.type !== 'alch') return;
@@ -74,15 +74,15 @@ describe('attemptZeroTimeActivity', () => {
 		});
 
 		const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'alch', itemID: item.id };
-                const response = attemptZeroTimeActivity({
-                        user,
-                        duration: timePerAlch * 10,
-                        preferences: [preference],
-                        alch: { variant: 'default' }
-                });
+		const response = attemptZeroTimeActivity({
+			user,
+			duration: timePerAlch * 10,
+			preferences: [preference],
+			alch: { variant: 'default' }
+		});
 
-                expect(response.result).toBeNull();
-                expect(response.failures[0]?.message).toBe("You're missing resources to alch Yew longbow.");
+		expect(response.result).toBeNull();
+		expect(response.failures[0]?.message).toBe("You're missing resources to alch Yew longbow.");
 	});
 
 	test('fletching success', () => {
@@ -97,15 +97,15 @@ describe('attemptZeroTimeActivity', () => {
 		});
 
 		const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'fletch', itemID: fletchable.id };
-                const response = attemptZeroTimeActivity({
-                        user,
-                        duration,
-                        preferences: [preference]
-                });
+		const response = attemptZeroTimeActivity({
+			user,
+			duration,
+			preferences: [preference]
+		});
 
-                expect(response.failures).toHaveLength(0);
-                expect(response.result?.type).toBe('fletch');
-                if (!response.result || response.result.type !== 'fletch') return;
+		expect(response.failures).toHaveLength(0);
+		expect(response.result?.type).toBe('fletch');
+		if (!response.result || response.result.type !== 'fletch') return;
 
 		expect(response.result.quantity).toBe(200);
 		const expectedRemove = fletchable.inputItems.clone().multiply(200);
@@ -137,14 +137,14 @@ describe('attemptZeroTimeActivity', () => {
 			});
 			const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'fletch', itemID: fletchable.id };
 
-                        const baseResponse = attemptZeroTimeActivity({
-                                user: baseUser,
-                                duration,
-                                preferences: [preference]
-                        });
+			const baseResponse = attemptZeroTimeActivity({
+				user: baseUser,
+				duration,
+				preferences: [preference]
+			});
 
-                        expect(baseResponse.failures).toHaveLength(0);
-                        expect(baseResponse.result?.type).toBe('fletch');
+			expect(baseResponse.failures).toHaveLength(0);
+			expect(baseResponse.result?.type).toBe('fletch');
 			if (!baseResponse.result || baseResponse.result.type !== 'fletch') return;
 
 			expect(baseResponse.result.quantity).toBe(defaultSets);
@@ -157,15 +157,15 @@ describe('attemptZeroTimeActivity', () => {
 				skills_fletching: convertLVLtoXP(70)
 			});
 
-                        const overrideResponse = attemptZeroTimeActivity({
-                                user: overrideUser,
-                                duration,
-                                preferences: [preference],
-                                fletch: { itemsPerHour }
-                        });
+			const overrideResponse = attemptZeroTimeActivity({
+				user: overrideUser,
+				duration,
+				preferences: [preference],
+				fletch: { itemsPerHour }
+			});
 
-                        expect(overrideResponse.failures).toHaveLength(0);
-                        expect(overrideResponse.result?.type).toBe('fletch');
+			expect(overrideResponse.failures).toHaveLength(0);
+			expect(overrideResponse.result?.type).toBe('fletch');
 			if (!overrideResponse.result || overrideResponse.result.type !== 'fletch') return;
 
 			expect(overrideResponse.result.quantity).toBe(baseResponse.result.quantity);
@@ -201,15 +201,15 @@ describe('attemptZeroTimeActivity', () => {
 		});
 
 		const preference: ZeroTimeActivityPreference = { role: 'primary', type: 'fletch', itemID: fletchable.id };
-                const response = attemptZeroTimeActivity({
-                        user,
-                        duration: Time.Second * 10,
-                        preferences: [preference]
-                });
+		const response = attemptZeroTimeActivity({
+			user,
+			duration: Time.Second * 10,
+			preferences: [preference]
+		});
 
-                expect(response.result).toBeNull();
-                expect(response.failures[0]?.message).toBe(
-                        "You don't have the required Slayer unlocks to fletch Broad arrows."
-                );
+		expect(response.result).toBeNull();
+		expect(response.failures[0]?.message).toBe(
+			"You don't have the required Slayer unlocks to fletch Broad arrows."
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- reformat zero-time activity utilities, commands, and tests using Biome to comply with project tab indentation
- repair mock user factory definition after formatting regression in test utilities

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68dda54414908326b2a790746d813fe9