### PR TITLE
Fix lint warnings for zero time activities

### DIFF
--- a/src/mahoji/commands/zeroTimeActivity.ts
+++ b/src/mahoji/commands/zeroTimeActivity.ts
@@ -9,7 +9,6 @@ import {
 	attemptZeroTimeActivity,
 	formatZeroTimePreference,
 	getZeroTimeActivityPreferences,
-	type ZeroTimeActivityPreference,
 	type ZeroTimeActivityType
 } from '../../lib/util/zeroTimeActivity';
 
@@ -65,9 +64,11 @@ function getAutocompleteOptions(value: string) {
 
 function parseAlchItemInput(
 	user: MUser,
-	itemInput: string | null,
-	context: 'primary' | 'fallback'
-): { itemID: number | null; error?: string } {
+	itemInput: string | null
+): {
+	itemID: number | null;
+	error?: string;
+} {
 	if (!itemInput || itemInput.length === 0) {
 		return { itemID: null };
 	}
@@ -263,7 +264,7 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 
 			let primaryItemID: number | null = null;
 			if (primaryType === 'alch') {
-				const { itemID, error } = parseAlchItemInput(user, rawPrimaryItem ?? null, 'primary');
+				const { itemID, error } = parseAlchItemInput(user, rawPrimaryItem ?? null);
 				if (error) {
 					return error;
 				}
@@ -288,7 +289,7 @@ export const zeroTimeActivityCommand: OSBMahojiCommand = {
 				fallbackType = fallbackInput as ZeroTimeActivityType;
 
 				if (fallbackType === 'alch') {
-					const { itemID, error } = parseAlchItemInput(user, rawFallbackItem ?? null, 'fallback');
+					const { itemID, error } = parseAlchItemInput(user, rawFallbackItem ?? null);
 					if (error) {
 						return error;
 					}

--- a/src/tasks/minions/minigames/sepulchreActivity.ts
+++ b/src/tasks/minions/minigames/sepulchreActivity.ts
@@ -139,6 +139,7 @@ export const sepulchreTask: MinionTask = {
 			]
 		});
 
+		const fallbackNote = zeroTimePreferenceRole === 'fallback' ? ' (fallback preference)' : '';
 		let str = `${user}, ${user.minionName} finished doing the Hallowed Sepulchre ${quantity}x times (floor ${
 			floors[0]
 		}-${floors[floors.length - 1]}), and opened ${numCoffinsOpened}x coffins.\n\n${xpRes}\n${thievingXpRes}${
@@ -161,14 +162,14 @@ export const sepulchreTask: MinionTask = {
 
 			if (fletchable.outputMultiple) {
 				const fletchableName = `${fletchable.name}s`;
-				str += `\nYou also fletched ${fletchQuantity} sets of ${fletchableName} and received ${fletchingLoot}. ${fletchXpRes}.`;
+				str += `\nYou also fletched ${fletchQuantity} sets of ${fletchableName}${fallbackNote} and received ${fletchingLoot}. ${fletchXpRes}.`;
 			} else {
-				str += `\nYou also fletched ${fletchQuantity} ${fletchable.name} and received ${fletchXpRes}.`;
+				str += `\nYou also fletched ${fletchQuantity} ${fletchable.name}${fallbackNote} and received ${fletchXpRes}.`;
 			}
 		}
 
 		if (alchItem && alchQuantity > 0) {
-			str += `\nYou also alched ${alchQuantity}x ${alchItem.name}.`;
+			str += `\nYou also alched ${alchQuantity}x ${alchItem.name}${fallbackNote}.`;
 			if (savedRunesFromAlching > 0) {
 				str += ` Your Bryophyta's staff saved you ${savedRunesFromAlching} Nature runes.`;
 			}


### PR DESCRIPTION
## Summary
- remove the unused zero time preference import and context parameter while simplifying alch item parsing
- surface fallback preference notes when reporting zero-time actions during sepulchre runs

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68dda6dd2aac8326ae199c94b28e1cec