### PR TITLE
Fix autocomplete option typing and alch filter

### DIFF
--- a/src/lib/discord/autoCompleteHandler.ts
+++ b/src/lib/discord/autoCompleteHandler.ts
@@ -12,10 +12,10 @@ import { allCommands } from '@/mahoji/commands/allCommands.js';
 async function handleAutocomplete(
 	user: MUser,
 	command: ICommand | undefined,
-	autocompleteData: CommandInteractionOption[],
+	autocompleteData: readonly CommandInteractionOption[],
 	member: GuildMember | undefined,
 	option?: CommandOption,
-	contextOptions?: CommandInteractionOption[]
+	contextOptions?: readonly CommandInteractionOption[]
 ): Promise<APIApplicationCommandOptionChoice[]> {
 	if (!command || !autocompleteData) return [];
 	const data = autocompleteData.find(i => 'focused' in i && i.focused === true) ?? autocompleteData[0];
@@ -82,7 +82,7 @@ export async function autoCompleteHandler(interaction: AutocompleteInteraction) 
 	const choices = await handleAutocomplete(
 		user,
 		command,
-		(interaction.options as any).data as CommandInteractionOption[],
+		(interaction.options as any).data as readonly CommandInteractionOption[],
 		member
 	);
 	await interaction.respond(choices);

--- a/src/lib/discord/commandOptions.ts
+++ b/src/lib/discord/commandOptions.ts
@@ -147,7 +147,7 @@ export interface MahojiUserOption {
 }
 
 export interface AutocompleteContext {
-	options: CommandInteractionOption[];
+	options: readonly CommandInteractionOption[];
 	focusedOption: CommandInteractionOption;
 	option?: CommandOption;
 }

--- a/src/mahoji/commands/zeroTimeActivity.ts
+++ b/src/mahoji/commands/zeroTimeActivity.ts
@@ -23,7 +23,7 @@ interface AlchableAutocompleteItem {
 }
 
 const alchableAutocompleteItems: AlchableAutocompleteItem[] = Items.filter(
-	item => Boolean(item.highalch) && item.tradeable
+	item => Boolean(item.highalch) && Boolean(item.tradeable)
 ).map(item => ({
 	id: item.id,
 	name: item.name,


### PR DESCRIPTION
## Summary
- allow the autocomplete handler and context to accept readonly command options from discord.js
- ensure zero time alching autocomplete only includes tradeable items with an explicit boolean check

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68de42790eec8326916d9a8ae6f8cd07