### PR TITLE
Fix zero-time alch autocomplete and format laps zero-time info

### DIFF
--- a/src/mahoji/commands/laps.ts
+++ b/src/mahoji/commands/laps.ts
@@ -173,7 +173,7 @@ ${prefix} alching ${alchResult.quantity}x ${alchResult.item.name} while training
 		if (infoMessages.length > 0) {
 			response += `
 
-${infoMessages.join('')}`;
+${infoMessages.join('\n')}`;
 		}
 
 		const zeroTimePreferenceRole = fletchResult?.preference.role ?? alchResult?.preference.role ?? null;

--- a/src/mahoji/commands/zeroTimeActivity.ts
+++ b/src/mahoji/commands/zeroTimeActivity.ts
@@ -189,7 +189,14 @@ function parseAlchItemInput(
 		return { itemID: null };
 	}
 
-	const osItem = Items.get(itemInput);
+	const trimmedInput = itemInput.trim();
+	if (trimmedInput.length === 0) {
+		return { itemID: null };
+	}
+	const numericID = Number(trimmedInput);
+	const lookupValue = Number.isInteger(numericID) && numericID.toString() === trimmedInput ? numericID : trimmedInput;
+
+	const osItem = Items.get(lookupValue);
 	if (!osItem) {
 		return { itemID: null, error: 'That is not a valid item to alch.' };
 	}

--- a/tests/integration/commands/laps.test.ts
+++ b/tests/integration/commands/laps.test.ts
@@ -36,8 +36,8 @@ describe('laps command', () => {
 			quantity: 1
 		});
 
-		expect(response).toContain('Primary:');
-		expect(response).toContain('Fallback:');
-		expect(response).toMatch(/Primary: [^\n]+\nFallback:/);
+		expect(response).toContain('Primary alch:');
+		expect(response).toContain('Fallback fletch:');
+		expect(response).toMatch(/Primary alch: [^\n]+\nFallback fletch:/);
 	});
 });

--- a/tests/integration/commands/laps.test.ts
+++ b/tests/integration/commands/laps.test.ts
@@ -20,7 +20,7 @@ describe('laps command', () => {
 			skills_fletching: convertLVLtoXP(75)
 		});
 
-		await user.update({ minion_hasBought: true, minion_hasMinion: true });
+		await user.update({ minion_hasBought: true });
 
 		await user.runCommand(zeroTimeActivityCommand, {
 			set: {

--- a/tests/integration/commands/laps.test.ts
+++ b/tests/integration/commands/laps.test.ts
@@ -1,0 +1,43 @@
+import { Bank, convertLVLtoXP, Items } from 'oldschooljs';
+import { describe, expect, test } from 'vitest';
+
+import { zeroTimeFletchables } from '../../../src/lib/skilling/skills/fletching/fletchables/index.js';
+import { lapsCommand } from '../../../src/mahoji/commands/laps.js';
+import { zeroTimeActivityCommand } from '../../../src/mahoji/commands/zeroTimeActivity.js';
+import { createTestUser } from '../util.js';
+
+describe('laps command', () => {
+	test('formats zero-time info messages on separate lines', async () => {
+		const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
+		expect(fletchable).toBeDefined();
+		if (!fletchable) return;
+
+		const alchItem = Items.getOrThrow('Yew longbow');
+
+		const user = await createTestUser(new Bank(), {
+			skills_agility: convertLVLtoXP(50),
+			skills_magic: convertLVLtoXP(75),
+			skills_fletching: convertLVLtoXP(75)
+		});
+
+		await user.update({ minion_hasBought: true, minion_hasMinion: true });
+
+		await user.runCommand(zeroTimeActivityCommand, {
+			set: {
+				primary_type: 'alch',
+				primary_item: alchItem.name,
+				fallback_type: 'fletch',
+				fallback_item: fletchable.name
+			}
+		});
+
+		const response = await user.runCommand(lapsCommand, {
+			name: 'Gnome Stronghold Agility Course',
+			quantity: 1
+		});
+
+		expect(response).toContain('Primary:');
+		expect(response).toContain('Fallback:');
+		expect(response).toMatch(/Primary: [^\n]+\nFallback:/);
+	});
+});

--- a/tests/integration/commands/zeroTimeActivity.test.ts
+++ b/tests/integration/commands/zeroTimeActivity.test.ts
@@ -52,6 +52,24 @@ describe('Zero Time Activity Command', () => {
 		expect(activity.result && activity.result.type === 'alch' ? activity.result.quantity : null).toBe(5);
 	});
 
+	test('accepts numeric autocomplete values for alching', async () => {
+		const item = Items.getOrThrow('Yew longbow');
+		const user = await createTestUser(new Bank().add('Nature rune', 200).add('Fire rune', 500).add(item.id, 200), {
+			skills_magic: convertLVLtoXP(75)
+		});
+
+		const response = await user.runCommand(zeroTimeActivityCommand, {
+			set: {
+				primary_type: 'alch',
+				primary_item: item.id.toString()
+			}
+		});
+
+		expect(response).toContain('Primary: Alch Yew longbow');
+		await user.sync();
+		expect(user.user.zero_time_activity_primary_item).toBe(item.id);
+	});
+
 	test('allows automatic alch selection', async () => {
 		const user = await createTestUser(new Bank().add('Nature rune', 200).add('Fire rune', 500), {
 			skills_magic: convertLVLtoXP(75)


### PR DESCRIPTION
## Summary
- allow numeric autocomplete IDs when parsing zero-time alching preferences
- format agility lap zero-time status messages with line breaks
- cover numeric autocomplete parsing and laps zero-time messaging with integration tests

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68de69fb9b9c83268d2ac3980a2bedd8