### PR TITLE
Deduplicate zero-time preference handling

### DIFF
--- a/src/lib/util/zeroTimeActivity.ts
+++ b/src/lib/util/zeroTimeActivity.ts
@@ -19,6 +19,16 @@ import { unlimitedFireRuneProviders } from './unlimitedFireRuneProviders.js';
 export type ZeroTimeActivityType = zero_time_activity_type_enum;
 export type ZeroTimePreferenceRole = 'primary' | 'fallback';
 
+export function getEffectivePreferenceRole(
+	preferenceRole: ZeroTimePreferenceRole,
+	hasPrimaryPreference: boolean
+): ZeroTimePreferenceRole {
+	if (preferenceRole === 'fallback' && hasPrimaryPreference) {
+		return 'fallback';
+	}
+	return 'primary';
+}
+
 export interface ZeroTimeActivityPreference {
 	role: ZeroTimePreferenceRole;
 	type: ZeroTimeActivityType;
@@ -150,10 +160,7 @@ export function getZeroTimeActivityPreferences(user: MUser): ZeroTimePreferenceL
 }
 
 export function resolveConfiguredFletchItemsPerHour(preference: ZeroTimeActivityPreference): number | undefined {
-	if (!preference.itemID) {
-		return undefined;
-	}
-	const configuredFletchable = zeroTimeFletchables.find(item => item.id === preference.itemID);
+	const configuredFletchable = resolveZeroTimeFletchable(preference);
 	if (!configuredFletchable) {
 		return undefined;
 	}

--- a/src/mahoji/commands/laps.ts
+++ b/src/mahoji/commands/laps.ts
@@ -7,6 +7,7 @@ import type { AgilityActivityTaskOptions } from '@/lib/types/minions.js';
 import {
 	attemptZeroTimeActivity,
 	describeZeroTimePreference,
+	getEffectivePreferenceRole,
 	getZeroTimeActivityPreferences,
 	getZeroTimePreferenceLabel,
 	resolveConfiguredFletchItemsPerHour,
@@ -134,9 +135,7 @@ export const lapsCommand: OSBMahojiCommand = {
 			}
 
 			const actualPreferenceRole: ZeroTimePreferenceRole | null = outcome.result
-				? outcome.result.preference.role === 'fallback' && hasPrimaryPreference
-					? 'fallback'
-					: 'primary'
+				? getEffectivePreferenceRole(outcome.result.preference.role, hasPrimaryPreference)
 				: null;
 
 			const formattedFailures = outcome.failures

--- a/src/mahoji/lib/abstracted_commands/sepulchreCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/sepulchreCommand.ts
@@ -6,6 +6,7 @@ import addSubTaskToActivityTask from '@/lib/util/addSubTaskToActivityTask.js';
 import {
 	attemptZeroTimeActivity,
 	describeZeroTimePreference,
+	getEffectivePreferenceRole,
 	getZeroTimeActivityPreferences,
 	getZeroTimePreferenceLabel,
 	resolveConfiguredFletchItemsPerHour,
@@ -75,9 +76,7 @@ export async function sepulchreCommand(user: MUser, channelID: string) {
 		}
 
 		const actualPreferenceRole: ZeroTimePreferenceRole | null = outcome.result
-			? outcome.result.preference.role === 'fallback' && hasPrimaryPreference
-				? 'fallback'
-				: 'primary'
+			? getEffectivePreferenceRole(outcome.result.preference.role, hasPrimaryPreference)
 			: null;
 
 		const formattedFailures = outcome.failures

--- a/tests/integration/commands/sepulchre.test.ts
+++ b/tests/integration/commands/sepulchre.test.ts
@@ -1,0 +1,73 @@
+import { Bank, convertLVLtoXP, Items } from 'oldschooljs';
+import { describe, expect, test, vi } from 'vitest';
+
+import { zeroTimeFletchables } from '../../../src/lib/skilling/skills/fletching/fletchables/index.js';
+import * as handleTripFinishModule from '../../../src/lib/util/handleTripFinish.js';
+import { zeroTimeActivityCommand } from '../../../src/mahoji/commands/zeroTimeActivity.js';
+import { sepulchreCommand } from '../../../src/mahoji/lib/abstracted_commands/sepulchreCommand.js';
+import { createTestUser, TEST_CHANNEL_ID } from '../util.js';
+
+describe('sepulchre command', () => {
+	test('fallback-only configuration avoids fallback messaging', async () => {
+		const fletchable = zeroTimeFletchables.find(item => item.name === 'Steel dart');
+		expect(fletchable).toBeDefined();
+		if (!fletchable) return;
+
+		const gracefulItems = [
+			'Graceful hood',
+			'Graceful top',
+			'Graceful legs',
+			'Graceful boots',
+			'Graceful gloves',
+			'Graceful cape'
+		].map(name => Items.getOrThrow(name).id);
+
+		const user = await createTestUser(
+			new Bank({
+				Feather: 50_000,
+				'Steel dart tip': 50_000,
+				'Graceful hood': 1,
+				'Graceful top': 1,
+				'Graceful legs': 1,
+				'Graceful boots': 1,
+				'Graceful gloves': 1,
+				'Graceful cape': 1
+			}),
+			{
+				skills_agility: convertLVLtoXP(92),
+				skills_thieving: convertLVLtoXP(70),
+				skills_fletching: convertLVLtoXP(75)
+			}
+		);
+
+		await user.update({ minion_hasBought: true });
+		await user.equip('skilling', gracefulItems);
+
+		await user.runCommand(zeroTimeActivityCommand, {
+			set: {
+				fallback_type: 'fletch',
+				fallback_item: fletchable.name
+			}
+		});
+
+		const handleTripFinishSpy = vi.spyOn(handleTripFinishModule, 'handleTripFinish');
+
+		const response = await sepulchreCommand(user, TEST_CHANNEL_ID);
+
+		expect(response.toLowerCase()).not.toContain('fallback');
+
+		let lastCall: Parameters<(typeof handleTripFinishModule)['handleTripFinish']> | undefined;
+		try {
+			await user.runActivity();
+			lastCall = handleTripFinishSpy.mock.calls.at(-1);
+		} finally {
+			handleTripFinishSpy.mockRestore();
+		}
+
+		expect(lastCall).toBeDefined();
+		const messageArg = lastCall?.[2];
+		const content = typeof messageArg === 'string' ? messageArg : (messageArg?.content ?? '');
+		expect(content.toLowerCase()).not.toContain('fallback preference');
+		expect(content.toLowerCase()).not.toContain('fallback');
+	});
+});


### PR DESCRIPTION
## Summary
- add a shared helper for zero-time preference roles and reuse it in laps and Sepulchre
- reuse the existing zero-time fletchable resolver when calculating configured fletch rates
- add an integration test covering Sepulchre fallback-only zero-time messaging

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68dfea5771148326aed36a9ac201efa0