### PR TITLE
Address review feedback for command auto-sync

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import { preStartup } from '@/lib/preStartup.js';
 import { OldSchoolBotClient } from '@/lib/structures/OldSchoolBotClient.js';
 import { CACHED_ACTIVE_USER_IDS } from '@/lib/util/cachedUserIDs.js';
 import { logError } from '@/lib/util/logError.js';
+import { autoSyncOnStartup } from '@/mahoji/commands/sync/autoSyncOnStartup.js';
+import { installGracefulShutdown } from '@/mahoji/commands/sync/installGracefulShutdown.js';
 import { onStartup } from '@/mahoji/lib/events.js';
 import { exitCleanup } from '@/mahoji/lib/exitHandler.js';
 
@@ -117,7 +119,26 @@ client.on('guildCreate', guild => {
 });
 
 client.on('shardError', err => debugLog('Shard Error', { error: err.message }));
-client.once('ready', () => onStartup());
+client.once('ready', async () => {
+        try {
+                await autoSyncOnStartup({
+                        rest: globalClient.rest,
+                        clientId: globalConfig.clientID,
+                        supportGuildId: globalConfig.supportServerID,
+                        isProduction: globalConfig.isProduction
+                });
+        } catch (error) {
+                console.error('Failed to auto-sync application commands on startup:', error);
+        }
+
+        installGracefulShutdown({
+                rest: globalClient.rest,
+                clientId: globalConfig.clientID,
+                supportGuildId: globalConfig.supportServerID
+        });
+
+        await onStartup();
+});
 
 async function main() {
 	console.log('Starting up...');

--- a/src/mahoji/commands/sync/autoSyncOnStartup.ts
+++ b/src/mahoji/commands/sync/autoSyncOnStartup.ts
@@ -1,0 +1,34 @@
+import { REST, Routes } from 'discord.js';
+
+import { buildPayloadsFromAllCommands } from '@/mahoji/commands/sync/buildPayloads.js';
+
+export async function autoSyncOnStartup({
+        rest,
+        clientId,
+        supportGuildId,
+        isProduction
+}: {
+        rest: REST;
+        clientId: string;
+        supportGuildId: string;
+        isProduction: boolean;
+}) {
+        const { globalPayload, supportGuildPayload } = buildPayloadsFromAllCommands({ isProduction });
+
+        await rest.put(Routes.applicationGuildCommands(clientId, supportGuildId), {
+                body: supportGuildPayload
+        });
+        console.log('Synced support guild application commands on startup.');
+
+        if (isProduction) {
+                await rest.put(Routes.applicationCommands(clientId), {
+                        body: globalPayload
+                });
+                console.log('Synced global application commands on startup.');
+        } else {
+                await rest.put(Routes.applicationCommands(clientId), {
+                        body: []
+                });
+                console.log('Cleared global application commands on startup (non-production).');
+        }
+}

--- a/src/mahoji/commands/sync/buildPayloads.ts
+++ b/src/mahoji/commands/sync/buildPayloads.ts
@@ -1,0 +1,30 @@
+import { ApplicationCommandType, type RESTPostAPIApplicationCommandsJSONBody } from 'discord.js';
+
+import { convertCommandOptionToAPIOption, type ICommand } from '@/lib/discord/index.js';
+import { allCommands } from '@/mahoji/commands/allCommands.js';
+
+function convertCommandToAPICommand(cmd: ICommand): RESTPostAPIApplicationCommandsJSONBody {
+        return {
+                type: ApplicationCommandType.ChatInput,
+                name: cmd.name,
+                description: cmd.description,
+                options: cmd.options.map(convertCommandOptionToAPIOption)
+        };
+}
+
+export function buildPayloadsFromAllCommands({
+        isProduction
+}: {
+        isProduction: boolean;
+}): {
+        globalPayload: RESTPostAPIApplicationCommandsJSONBody[];
+        supportGuildPayload: RESTPostAPIApplicationCommandsJSONBody[];
+} {
+        const globalCommands = isProduction ? allCommands.filter(cmd => !cmd.guildID) : [];
+        const supportGuildCommands = isProduction ? allCommands.filter(cmd => Boolean(cmd.guildID)) : allCommands;
+
+        return {
+                globalPayload: globalCommands.map(convertCommandToAPICommand),
+                supportGuildPayload: supportGuildCommands.map(convertCommandToAPICommand)
+        };
+}

--- a/src/mahoji/commands/sync/installGracefulShutdown.ts
+++ b/src/mahoji/commands/sync/installGracefulShutdown.ts
@@ -1,0 +1,47 @@
+import { REST, Routes } from 'discord.js';
+
+let isInstalled = false;
+
+export function installGracefulShutdown({
+        rest,
+        clientId,
+        supportGuildId
+}: {
+        rest: REST;
+        clientId: string;
+        supportGuildId: string;
+}) {
+        if (isInstalled) {
+                return;
+        }
+        isInstalled = true;
+
+        let handlingSignal = false;
+
+        const clearGuildCommands = async () => {
+                try {
+                        await rest.put(Routes.applicationGuildCommands(clientId, supportGuildId), {
+                                body: []
+                        });
+                        console.log('Cleared support guild application commands on shutdown.');
+                } catch (error) {
+                        console.error('Failed to clear guild commands on shutdown:', error);
+                }
+        };
+
+        const handler = async () => {
+                if (handlingSignal) {
+                        return;
+                }
+                handlingSignal = true;
+
+                await clearGuildCommands();
+                process.exit(0);
+        };
+
+        (['SIGINT', 'SIGTERM'] as const).forEach(signal =>
+                process.on(signal, () => {
+                        void handler();
+                })
+        );
+}


### PR DESCRIPTION
## Summary
- add reusable payload builder shared by startup sync and the admin sync command
- automatically sync global and support guild commands on ready and clear the support guild on shutdown signals
- keep /admin sync_commands behaviour while using the shared helpers
- add explicit startup/shutdown logging and drop the unused shutdown isProduction argument

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff6f18fc483269cfd458713bb7ac1