### PR TITLE
Add command sync script and improve admin desync handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"spritesheet": "tsx --tsconfig scripts/tsconfig.json ./scripts/spritesheet.ts && pnpm lint",
 		"data": "tsx --tsconfig scripts/tsconfig.json ./scripts/monster_table.ts && pnpm lint",
 		"wiki": "tsx --tsconfig scripts/tsconfig.json ./scripts/wiki.ts && pnpm lint",
+		"sync:commands": "tsx --tsconfig scripts/tsconfig.json scripts/syncCommands.ts",
 		"generate:robochimp": "prisma generate --no-hints --schema prisma/robochimp.prisma",
 		"bso-data": "git fetch origin bso:bso && git checkout bso -- ./data/bso/ && git diff --name-only master bso | sort > data/misc/bso-diff.txt",
 		"============BUILDING": "============",

--- a/scripts/syncCommands.ts
+++ b/scripts/syncCommands.ts
@@ -1,0 +1,26 @@
+import './base.js';
+
+import { REST } from 'discord.js';
+
+import { globalConfig } from '@/lib/constants.js';
+import { bulkUpdateCommands } from '@/lib/discord/utils.js';
+import { allCommandsDONTIMPORT } from '@/mahoji/commands/allCommands.js';
+
+async function main() {
+	const rest = new REST({ version: '10' }).setToken(globalConfig.botToken);
+	await bulkUpdateCommands({
+		commands: allCommandsDONTIMPORT,
+		rest,
+		applicationID: globalConfig.clientID
+	});
+}
+
+main()
+	.then(() => {
+		console.log('Slash commands synced.');
+		process.exit(0);
+	})
+	.catch(err => {
+		console.error('Failed to sync slash commands.', err);
+		process.exit(1);
+	});

--- a/src/mahoji/commands/admin.ts
+++ b/src/mahoji/commands/admin.ts
@@ -875,7 +875,9 @@ Guilds Blacklisted: ${BLACKLISTED_GUILDS.size}`;
 			}
 
 			// Keep only the admin toolset (adjust names if needed)
-			const adminCommands = allCommands.filter(cmd => cmd.name === 'admin' || cmd.name === 'rp');
+			const adminCommands = globalClient.allCommands.filter(
+				command => command.name === 'admin' || command.name === 'rp'
+			);
 
 			// Always overwrite the current guild with just the admin commands
 			await bulkUpdateCommands({
@@ -891,7 +893,9 @@ Guilds Blacklisted: ${BLACKLISTED_GUILDS.size}`;
 				});
 			}
 
-			return `Desynced commands in this guild; kept ${adminCommands.map(c => `/${c.name}`).join(', ') || '/admin'}.`;
+			return `Desynced commands in this guild; kept ${
+				adminCommands.map(command => `/${command.name}`).join(', ') || '/admin'
+			}.`;
 		}
 
 		if (options.view) {


### PR DESCRIPTION
## Summary
- allow `bulkUpdateCommands` to accept overrides for target commands, REST client, and application ID
- fix the admin desync subcommand to use the global command list and provide typed logging of kept commands
- add a standalone `scripts/syncCommands.ts` and `pnpm sync:commands` helper for manual slash command syncs

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68e4c54e16cc8326a2806c89620c4d7d