### PR TITLE
Open spirit seed trades into tier 5 loot

### DIFF
--- a/src/mahoji/commands/sell.ts
+++ b/src/mahoji/commands/sell.ts
@@ -6,6 +6,7 @@ import { clamp } from 'remeda';
 import { userhasDiaryTier, WildernessDiary } from '@/lib/diaries.js';
 import { filterOption } from '@/lib/discord/index.js';
 import { NestBoxesTable } from '@/lib/simulation/misc.js';
+import { Farming } from '@/lib/skilling/skills/farming/index.js';
 import { parseBank } from '@/lib/util/parseStringBank.js';
 
 /**
@@ -148,6 +149,30 @@ export const sellCommand: OSBMahojiCommand = {
 				itemsToRemove: abbyBank
 			});
 			return `You exchanged ${abbyBank} and received: ${loot}.`;
+		}
+
+		if (bankToSell.has('Spirit seed')) {
+			const quantity = bankToSell.amount('Spirit seed');
+			const seedsBank = new Bank().add('Spirit seed', quantity);
+
+			await interaction.confirmation(
+				`${user}, please confirm you want to trade ${seedsBank} for Tier 5 seed pack loot.`
+			);
+
+			const loot = new Bank();
+			for (let i = 0; i < quantity; i++) {
+				loot.add(Farming.openSeedPack(5));
+			}
+
+			await user.transactItems({
+				collectionLog: false,
+				itemsToAdd: loot,
+				itemsToRemove: seedsBank
+			});
+
+			await user.addItemsToCollectionLog(new Bank().add('Seed pack', quantity));
+
+			return `You exchanged ${seedsBank} and received: ${loot}.`;
 		}
 
 		if (


### PR DESCRIPTION
## Summary
- open spirit seed trades immediately into Tier 5 seed pack loot
- grant seed pack collection log credit matching the number of traded spirit seeds

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68e4ca5724888326b1a659e01a645397