### PR TITLE
Fix farming test mocks for graceful gear and item exports

### DIFF
--- a/tests/unit/autoFarm.integration.test.ts
+++ b/tests/unit/autoFarm.integration.test.ts
@@ -166,6 +166,7 @@ function createAutoFarmStub({
 		addItemsToCollectionLog: vi.fn().mockResolvedValue(undefined),
 		hasEquippedOrInBank: vi.fn().mockReturnValue(false),
 		hasEquipped: vi.fn().mockReturnValue(false),
+		hasGracefulEquipped: vi.fn().mockReturnValue(false),
 		farmingContract: vi.fn().mockReturnValue({
 			contract: {
 				plantsContract: null,

--- a/tests/unit/farmingActivity.test.ts
+++ b/tests/unit/farmingActivity.test.ts
@@ -87,7 +87,8 @@ vi.mock('@/lib/skilling/skills/farming/index.js', () => ({
 	Farming: {
 		Plants: [redwoodPlant, herbPlant],
 		calcVariableYield: calcVariableYieldMock
-	}
+	},
+	allFarmingItems: []
 }));
 
 vi.mock('@/lib/util/handleTripFinish.js', () => ({


### PR DESCRIPTION
## Summary
- add a `hasGracefulEquipped` helper to the auto farm integration user stub so tests use the expected API
- expose an `allFarmingItems` export from the farming activity mock to satisfy collection lookups

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68e4cd67c8248326b8a52f7ac31ef3cf