### PR TITLE
Fix minigame leaderboard type definitions

### DIFF
--- a/src/mahoji/commands/leaderboard.ts
+++ b/src/mahoji/commands/leaderboard.ts
@@ -247,7 +247,7 @@ LIMIT 10;
 	return lbMsg('Unique Sacrifice');
 }
 
-async function minigamesLb(interaction: ChatInputCommandInteraction, user: MUser, name: string, ironmanOnly: boolean) {
+async function minigamesLb(interaction: MInteraction, name: string, ironmanOnly: boolean) {
 	const minigame = Minigames.find(m => stringMatches(m.name, name) || m.aliases.some(a => stringMatches(a, name)));
 	if (!minigame) {
 		return `That's not a valid minigame. Valid minigames are: ${Minigames.map(m => m.name).join(', ')}.`;
@@ -294,7 +294,6 @@ async function minigamesLb(interaction: ChatInputCommandInteraction, user: MUser
 
 	return doMenuWrapper({
 		ironmanOnly,
-		user,
 		interaction,
 		users: res.map(u => ({ id: u.user_id, score: u[minigame.column] })),
 		title: `${minigame.name} Leaderboard`
@@ -1142,7 +1141,7 @@ export const leaderboardCommand: OSBMahojiCommand = {
 			return sacrificeLb(interaction, sacrifice.type, Boolean(sacrifice.ironmen_only));
 		}
 		if (minigames) {
-			return minigamesLb(interaction, user, minigames.minigame, Boolean(minigames.ironmen_only));
+			return minigamesLb(interaction, minigames.minigame, Boolean(minigames.ironmen_only));
 		}
 		if (hunter_catches) {
 			return creaturesLb(interaction, hunter_catches.creature);

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -1,6 +1,8 @@
 import { describe, test } from 'vitest';
 
+import { leaderboardCommand } from '../../src/mahoji/commands/leaderboard.js';
 import { kcGains } from '../../src/mahoji/commands/tools.js';
+import { createTestUser } from './util.js';
 
 describe('Leaderboard', async () => {
 	test('kcGains Leaderboard', async () => {


### PR DESCRIPTION
## Summary
- ensure the minigames leaderboard handler uses the shared interaction type and remove the unused user argument to resolve type errors
- add missing imports for the leaderboard integration test helper and command

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68e4dbd42d288326944ca2c7f2b38258