### PR TITLE
Fix combined auto farm auto contract test setup

### DIFF
--- a/tests/unit/combinedAutoFarmActivity.test.ts
+++ b/tests/unit/combinedAutoFarmActivity.test.ts
@@ -46,7 +46,7 @@ describe('handleCombinedAutoFarm auto contract button behaviour', () => {
 			updateBankSetting: vi.fn().mockResolvedValue(undefined)
 		});
 
-		executeFarmingStepMock.mockResolvedValue({
+		executeFarmingStepMock.mockImplementation(async () => ({
 			message: 'finished step',
 			loot: new Bank().add('Seed pack', 1),
 			summary: {
@@ -64,7 +64,7 @@ describe('handleCombinedAutoFarm auto contract button behaviour', () => {
 				xpMessages: {},
 				contractCompleted: true
 			}
-		});
+		}));
 
 		user = {
 			id: '1',
@@ -92,6 +92,7 @@ describe('handleCombinedAutoFarm auto contract button behaviour', () => {
 			patchType: {} as any,
 			userID: '1',
 			channelID: '123',
+			id: 123,
 			quantity: 1,
 			upgradeType: null,
 			payment: false,
@@ -127,7 +128,6 @@ describe('handleCombinedAutoFarm auto contract button behaviour', () => {
 		canRunAutoContractMock.mockResolvedValue(true);
 
 		await handleCombinedAutoFarm({ user: user as any, taskData });
-
 		expect(executeFarmingStepMock).toHaveBeenCalledTimes(1);
 		expect(handleTripFinishMock).toHaveBeenCalledTimes(1);
 		const extraComponents = handleTripFinishMock.mock.calls[0]?.[7];


### PR DESCRIPTION
## Summary
- update the combined auto farm test to use an async farming step mock so the handler processes a completed contract
- include a task id in the mocked task data to match the activity interface

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68e4f257c818832699c8cb0aa0b680b8