### PR TITLE
Fix combined auto farm test mocking

### DIFF
--- a/tests/unit/combinedAutoFarmActivity.test.ts
+++ b/tests/unit/combinedAutoFarmActivity.test.ts
@@ -1,5 +1,5 @@
 import { Bank } from 'oldschooljs';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BitField } from '../../src/lib/constants.js';
 import type { FarmingActivityTaskOptions } from '../../src/lib/types/minions.js';
@@ -26,7 +26,11 @@ vi.mock('@/mahoji/lib/abstracted_commands/farmingContractCommand.js', () => ({
 	canRunAutoContract: canRunAutoContractMock
 }));
 
-const { handleCombinedAutoFarm } = await import('../../src/tasks/minions/combinedAutoFarmActivity.js');
+let handleCombinedAutoFarm: typeof import('@/tasks/minions/combinedAutoFarmActivity.js')['handleCombinedAutoFarm'];
+
+beforeAll(async () => {
+	({ handleCombinedAutoFarm } = await import('@/tasks/minions/combinedAutoFarmActivity.js'));
+});
 
 describe('handleCombinedAutoFarm auto contract button behaviour', () => {
 	let user: MUserStub;


### PR DESCRIPTION
## Summary
- load `handleCombinedAutoFarm` in the combined auto farm unit test via the alias path inside a `beforeAll`
- ensure the Vitest mock setup runs before the module import so the mocked dependencies are exercised

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68e4f257c818832699c8cb0aa0b680b8