### PR TITLE
Fix combined auto farm test mocks

### DIFF
--- a/tests/unit/combinedAutoFarmActivity.test.ts
+++ b/tests/unit/combinedAutoFarmActivity.test.ts
@@ -13,7 +13,15 @@ vi.mock('@/tasks/minions/farmingStep.js', () => ({
 	__esModule: true,
 	executeFarmingStep: executeFarmingStepMock
 }));
+vi.mock('../../src/tasks/minions/farmingStep.js', () => ({
+	__esModule: true,
+	executeFarmingStep: executeFarmingStepMock
+}));
 vi.mock('@/lib/util/handleTripFinish.js', () => ({
+	__esModule: true,
+	handleTripFinish: handleTripFinishMock
+}));
+vi.mock('../../src/lib/util/handleTripFinish.js', () => ({
 	__esModule: true,
 	handleTripFinish: handleTripFinishMock
 }));
@@ -21,7 +29,15 @@ vi.mock('@/lib/util/interactions.js', () => ({
 	__esModule: true,
 	makeAutoContractButton: makeAutoContractButtonMock
 }));
+vi.mock('../../src/lib/util/interactions.js', () => ({
+	__esModule: true,
+	makeAutoContractButton: makeAutoContractButtonMock
+}));
 vi.mock('@/mahoji/lib/abstracted_commands/farmingContractCommand.js', () => ({
+	__esModule: true,
+	canRunAutoContract: canRunAutoContractMock
+}));
+vi.mock('../../src/mahoji/lib/abstracted_commands/farmingContractCommand.js', () => ({
 	__esModule: true,
 	canRunAutoContract: canRunAutoContractMock
 }));


### PR DESCRIPTION
## Summary
- ensure combined auto farm unit tests mock both aliased and relative module paths for farming step, trip finish, interactions, and auto contract helpers

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68e4f257c818832699c8cb0aa0b680b8