### PR TITLE
Fix osjsMonster reference in degradeable boost charges

### DIFF
--- a/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
+++ b/src/mahoji/lib/abstracted_commands/minionKill/speedBoosts.ts
@@ -393,7 +393,7 @@ export const mainBoostEffects: (Boost | Boost[])[] = [
 						const chargesNeeded = Math.ceil(
 							degItem.charges({
 								killableMon: monster,
-								osjsMonster,
+								osjsMonster: osjsMon,
 								totalHP: (osjsMon?.data.hitpoints ?? monster.customMonsterHP ?? 100) * quantity,
 								duration
 							})


### PR DESCRIPTION
## Summary
- fix the degradeable boost charge calculation to pass the active osrs monster context

## Testing
- pnpm test:lint

------
https://chatgpt.com/codex/tasks/task_e_68e63bcc5b74832682347fba645f776b