### PR TITLE
Use canonical OSRS wiki page names for monster links (strip trailing parentheticals)

### DIFF
--- a/docs/src/content/docs/osb/monsters.mdx
+++ b/docs/src/content/docs/osb/monsters.mdx
@@ -2230,7 +2230,7 @@ Melee gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [Duke Sucellus (Awakened)](https://oldschool.runescape.wiki/w/Duke%20Sucellus%20(Awakened))
+    - You can view the drops for this monster on the osrs wiki: [Duke Sucellus (Awakened)](https://oldschool.runescape.wiki/w/Duke%20Sucellus)
 
 - You can send your minion to kill this monster using: [[/k name\:Duke Sucellus (Awakened)]]
 
@@ -4144,7 +4144,7 @@ Mage gear boosts, it is **required** to have atleast one of these:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [Royal Titans (Branda)](https://oldschool.runescape.wiki/w/Royal%20Titans%20(Branda))
+    - You can view the drops for this monster on the osrs wiki: [Royal Titans (Branda)](https://oldschool.runescape.wiki/w/Royal%20Titans)
 
 - You can send your minion to kill this monster using: [[/k name\:Royal Titans (Branda)]]
 
@@ -4283,7 +4283,7 @@ Melee gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [Royal Titans (Eldric)](https://oldschool.runescape.wiki/w/Royal%20Titans%20(Eldric))
+    - You can view the drops for this monster on the osrs wiki: [Royal Titans (Eldric)](https://oldschool.runescape.wiki/w/Royal%20Titans)
 
 - You can send your minion to kill this monster using: [[/k name\:Royal Titans (Eldric)]]
 
@@ -4422,7 +4422,7 @@ Melee gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [Royal Titans (sacrifice)](https://oldschool.runescape.wiki/w/Royal%20Titans%20(sacrifice))
+    - You can view the drops for this monster on the osrs wiki: [Royal Titans (sacrifice)](https://oldschool.runescape.wiki/w/Royal%20Titans)
 
 - You can send your minion to kill this monster using: [[/k name\:Royal Titans (sacrifice)]]
 
@@ -5426,7 +5426,7 @@ Range gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [The Leviathan (Awakened)](https://oldschool.runescape.wiki/w/The%20Leviathan%20(Awakened))
+    - You can view the drops for this monster on the osrs wiki: [The Leviathan (Awakened)](https://oldschool.runescape.wiki/w/The%20Leviathan)
 
 - You can send your minion to kill this monster using: [[/k name\:The Leviathan (Awakened)]]
 
@@ -5659,7 +5659,7 @@ Range gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [The Whisperer (Awakened)](https://oldschool.runescape.wiki/w/The%20Whisperer%20(Awakened))
+    - You can view the drops for this monster on the osrs wiki: [The Whisperer (Awakened)](https://oldschool.runescape.wiki/w/The%20Whisperer)
 
 - You can send your minion to kill this monster using: [[/k name\:The Whisperer (Awakened)]]
 
@@ -6302,7 +6302,7 @@ Melee gear boosts:
 
 <Tabs>
 <TabItem label="Information">
-    - You can view the drops for this monster on the osrs wiki: [Vardorvis (Awakened)](https://oldschool.runescape.wiki/w/Vardorvis%20(Awakened))
+    - You can view the drops for this monster on the osrs wiki: [Vardorvis (Awakened)](https://oldschool.runescape.wiki/w/Vardorvis)
 
 - You can send your minion to kill this monster using: [[/k name\:Vardorvis (Awakened)]]
 

--- a/scripts/wiki/renderMonsters.ts
+++ b/scripts/wiki/renderMonsters.ts
@@ -12,6 +12,10 @@ function escapeItemName(str: string) {
 
 const name = (id: number) => escapeItemName(Items.itemNameFromId(id)!);
 
+function getOSRSWikiPageName(monsterName: string) {
+	return monsterName.replace(/\s+\([^)]*\)$/, '');
+}
+
 export function renderMonstersMarkdown() {
 	const markdown = new Markdown();
 
@@ -21,8 +25,9 @@ export function renderMonstersMarkdown() {
 
 		const infoTab = new Tab().setTitle('Information').setContent(() => {
 			const md = new Markdown();
+			const wikiName = getOSRSWikiPageName(monster.name);
 			md.addLine(
-				`- You can view the drops for this monster on the osrs wiki: [${monster.name}](https://oldschool.runescape.wiki/w/${encodeURIComponent(monster.name)})`
+				`- You can view the drops for this monster on the osrs wiki: [${monster.name}](https://oldschool.runescape.wiki/w/${encodeURIComponent(wikiName)})`
 			);
 			md.addLine(`- You can send your minion to kill this monster using: [[/k name:${monster.name}]]`);
 			md.addLine(`- You can check your KC using: [[/minion kc name:${monster.name}]]`);


### PR DESCRIPTION
### Motivation

- Generated monster wiki links included trailing parenthetical qualifiers (e.g. "(Awakened)") which point to non-canonical OSRS Wiki URLs, so links should use the base page name.

### Description

- Add `getOSRSWikiPageName` to strip trailing parenthetical qualifiers from a monster name using a regex. 
- Use the stripped `wikiName` when building the OSRS Wiki link in `renderMonsters.ts`. 
- Regenerate `docs/src/content/docs/osb/monsters.mdx` to update existing monster links to the canonical wiki pages.

### Testing

- Regenerated the monster docs by running the render script `node scripts/wiki/renderMonsters.ts` and verified the output changed as expected. 
- Ran the TypeScript build with `npm run build` to ensure there were no type errors and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df45abfa1c8326a40c784f7ff0d57c)