### PR TITLE
OuraniaAltar: Only apply Graceful penalty when neither Graceful nor Spellbook Swap is available

### DIFF
--- a/src/mahoji/lib/abstracted_commands/ouraniaAltarCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/ouraniaAltarCommand.ts
@@ -41,8 +41,8 @@ export async function ouraniaAltarStartCommand({
 
 	if (inventorySize > 28) boosts.push(`+${inventorySize - 28} inv spaces from pouches`);
 
-	if (!user.hasGracefulEquipped() || !spellbookSwap) {
-		boosts.push(`${gracefulPenalty}% slower for no Graceful`);
+	if (!user.hasGracefulEquipped() && !spellbookSwap) {
+		boosts.push(`${gracefulPenalty}% slower without Graceful or Spellbook Swap`);
 		timePerTrip = increaseNumByPercent(timePerTrip, gracefulPenalty);
 	}
 


### PR DESCRIPTION
### Motivation
- Prevent the 20% Graceful time penalty from applying when the user has either full Graceful equipped or the Spellbook Swap boost, matching intended boost interactions.

### Description
- Change the condition in `src/mahoji/lib/abstracted_commands/ouraniaAltarCommand.ts` from `if (!user.hasGracefulEquipped() || !spellbookSwap)` to `if (!user.hasGracefulEquipped() && !spellbookSwap)` so the penalty only applies when both are missing.
- Update the displayed boost text to `"${gracefulPenalty}% slower without Graceful or Spellbook Swap"` and keep the `timePerTrip` increase via `increaseNumByPercent`.

### Testing
- Ran `pnpm test:lint` and it completed successfully with no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a6388a2c8326a9f56caf6711c2b5)