### PR TITLE
Propagate channelId to Farming activities and include user in farming step messages

### DIFF
--- a/src/mahoji/commands/farming.ts
+++ b/src/mahoji/commands/farming.ts
@@ -464,6 +464,7 @@ export const farmingCommand = defineCommand({
 			return farmingPlantCommand({
 				user,
 				interaction,
+				channelId,
 				plantName: options.plant.plant_name,
 				quantity: options.plant.quantity ?? null,
 				autoFarmed: false,
@@ -474,7 +475,8 @@ export const farmingCommand = defineCommand({
 			return harvestCommand({
 				user: user,
 				seedType: options.harvest.patch_name,
-				interaction
+				interaction,
+				channelId
 			});
 		}
 		if (options.tithe_farm) {

--- a/src/mahoji/lib/abstracted_commands/farmingCommand.ts
+++ b/src/mahoji/lib/abstracted_commands/farmingCommand.ts
@@ -17,11 +17,13 @@ import { formatTripDuration } from '@/lib/util/minionUtils.js';
 export async function harvestCommand({
 	user,
 	seedType,
-	interaction
+	interaction,
+	channelId = interaction.channelId
 }: {
 	user: MUser;
 	seedType: string;
 	interaction: MInteraction;
+	channelId?: string;
 }) {
 	if (await user.minionIsBusy()) {
 		return 'Your minion must not be busy to use this command.';
@@ -90,7 +92,7 @@ It'll take around ${formatTripDuration(user, duration)} to finish.${formatFarmin
 		plantsName: patch.lastPlanted,
 		patchType: patches[patch.patchName],
 		userID: user.id,
-		channelId: interaction.channelId,
+		channelId,
 		upgradeType,
 		duration,
 		quantity: patch.lastQuantity,
@@ -106,6 +108,7 @@ It'll take around ${formatTripDuration(user, duration)} to finish.${formatFarmin
 export async function farmingPlantCommand({
 	user,
 	interaction,
+	channelId = interaction.channelId,
 	plantName,
 	quantity,
 	autoFarmed,
@@ -113,6 +116,7 @@ export async function farmingPlantCommand({
 }: {
 	user: MUser;
 	interaction: MInteraction;
+	channelId?: string;
 	plantName: string;
 	quantity: number | null;
 	autoFarmed: boolean;
@@ -218,7 +222,7 @@ export async function farmingPlantCommand({
 		plantsName: plant.name,
 		patchType: patches[plant.seedType],
 		userID: user.id,
-		channelId: interaction.channelId,
+		channelId,
 		quantity,
 		upgradeType,
 		payment: didPay,

--- a/src/tasks/minions/farmingStep.ts
+++ b/src/tasks/minions/farmingStep.ts
@@ -862,7 +862,7 @@ export async function executeFarmingStep({
 			? xpBreakdownParts.join(', ').replace(/, ([^,]*)$/, ', and $1')
 			: xpBreakdownParts[0];
 	infoStr.push(
-		`${plantingStr}harvesting ${patchType.lastQuantity}x ${plantToHarvest.name}.${payStr}\n\nYou received ${xpBreakdown}. In total: ${xpRes}. ${
+		`${user}, ${plantingStr}harvesting ${patchType.lastQuantity}x ${plantToHarvest.name}.${payStr}\n\nYou received ${xpBreakdown}. In total: ${xpRes}. ${
 			woodcuttingOutcome.woodcuttingOccurred ? wcXP : ''
 		}`
 	);

--- a/tests/unit/farmingStep.test.ts
+++ b/tests/unit/farmingStep.test.ts
@@ -85,6 +85,7 @@ describe('farmingStep tree fee handling', () => {
 		});
 
 		expect(result).not.toBeNull();
+		expect(result?.message).toContain(`${user}`);
 		expect(removeItemsFromBankSpy).not.toHaveBeenCalled();
 		expect(addItemsToBankSpy).toHaveBeenCalledTimes(1);
 		const refundArg = addItemsToBankSpy.mock.calls[0]?.[0] as { items: Bank } | undefined;


### PR DESCRIPTION
### Motivation

- Ensure farming activity tasks post results to the correct channel by forwarding the originating `channelId` into activity start calls.
- Make farming step result messages clearer by including the invoking user in the returned message for better context.

### Description

- Propagated `channelId` from the mahoji farming command into `harvestCommand` and `farmingPlantCommand` calls in `src/mahoji/commands/farming.ts`.
- Added optional `channelId` parameters (defaulting to `interaction.channelId`) to `harvestCommand` and `farmingPlantCommand` in `src/mahoji/lib/abstracted_commands/farmingCommand.ts` and used that value when calling `ActivityManager.startTrip`.
- Prefixed the farming step info message with the user string in `src/tasks/minions/farmingStep.ts` so the returned `message` contains the user context.
- Updated unit test `tests/unit/farmingStep.test.ts` to assert the farming step `message` contains the user.

### Testing

- Ran the updated unit test `tests/unit/farmingStep.test.ts` which passed and confirms the farming step message contains the user string.
- Verified the modified unit assertions around bank operations and refund behavior still pass in the same test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a324d4718048326b809e80a37603484)